### PR TITLE
Fix XOR login TLVs

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProtocol.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProtocol.java
@@ -139,9 +139,11 @@ public class ICQProtocol {
         buffer.writeDWord(TLV_0X14_DISTRIBUTION);
 
         buffer.writeWord(0x0f);
+        buffer.writeWord(TLV_LANGUAGE.length());
         buffer.writeStringAscii(TLV_LANGUAGE);
 
         buffer.writeWord(0x0e);
+        buffer.writeWord(TLV_COUNTRY.length());
         buffer.writeStringAscii(TLV_COUNTRY);
 
 


### PR DESCRIPTION
## Summary
- fix TLV lengths for language and country fields in XOR login

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612807c8a883239425c8a7a2ff9097