### PR TITLE
Fix XOR login buffer allocation

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProtocol.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProtocol.java
@@ -102,7 +102,9 @@ public class ICQProtocol {
 
     public static ByteBuffer createXORLogin(int seq, String uin, String password) throws Exception {
         String pass = password.length() > 8 ? password.substring(0, 8) : password;
-        ByteBuffer buffer = new ByteBuffer(ContactListActivity.UPDATE_BLINK_STATE);
+        // Allocate extra space for the long legacy client string and TLVs
+        ByteBuffer buffer =
+                new ByteBuffer(ContactListActivity.UPDATE_BLINK_STATE + CLIENT_STRING.length());
         buffer.writeDWord(1);
         buffer.writeWord(1);
         buffer.writePreLengthStringAscii(uin);


### PR DESCRIPTION
## Summary
- ensure the XOR login buffer can hold legacy client data

## Testing
- `./gradlew build -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612c7d13b08323a47df46df62a2dc2