### PR TITLE
Fix contact list update after service connection

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -406,6 +406,9 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
         }
         if (listAdp != null) {
             refreshContactlist();
+            if (listAdp.getCount() == 0 && service != null && service.profiles != null) {
+                createContactlistFromProfiles();
+            }
         }
         if (switcher != null) {
             switcher.updateConfig();


### PR DESCRIPTION
## Summary
- refresh contact list if adapter empty on resume

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615bf050cc8323bd92c4f7b9e1b1a8