### PR TITLE
Fix SlideSwitcher freeze when interrupting wrap

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -383,6 +383,9 @@ public class SlideSwitcher extends ViewGroup {
                 } else {
                     this.mIsBeingDragged = true;
                     this.scroller.forceFinished(true);
+                    this.wrap_mode = false;
+                    this.wrap_direction = 0;
+                    setAnimationState(false);
                     return true;
                 }
             case 1:


### PR DESCRIPTION
## Summary
- prevent SlideSwitcher wrap lock when user interrupts animation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615fab12f08323a99b76db7cfe01d3