### PR TITLE
Fix crash opening server settings

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/SettingsActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/SettingsActivity.java
@@ -169,10 +169,10 @@ public class SettingsActivity extends PreferenceActivity {
                 lp.setNegativeButtonText(resources.getString("s_cancel"));
             }
 
-        if (!title.equals("null")) {
+        if (title != null && !title.equals("null")) {
             preference.setTitle(title);
             String desc = resources.getString("s_" + p + "_desc");
-            if (!desc.equals("null")) {
+            if (desc != null && !desc.equals("null")) {
                 preference.setSummary(desc);
             }
         }


### PR DESCRIPTION
## Summary
- avoid NPE when preference description is missing

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861641bfc0c8323b76a36ea9e2391c4