### PR TITLE
Fix UIN parsing in roster

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/IncomingRosterParser.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/IncomingRosterParser.java
@@ -24,10 +24,6 @@ public class IncomingRosterParser {
                 if (group == 0) {
                     buffer.skip(additionalLength);
                 } else {
-                    if (itemName.length() > 9 && utilities.isUIN(itemName)) {
-                        //noinspection StringOperationCanBeSimplified
-                        itemName = itemName.substring(itemName.length() - 9, itemName.length());
-                    }
                     ICQContact contact = profile.contactlist.getContactByUIN(itemName);
                     if (contact != null) {
                         contact.ID = itemName;


### PR DESCRIPTION
## Summary
- stop truncating ICQ UINs in `IncomingRosterParser`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861653e51d08323a1681dba84878d82