### PR TITLE
Improve message error logging

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
@@ -1166,7 +1166,7 @@ public class ICQProfile extends IMProfile {
                 Log.v("Jasmine:Message Error!", "receiver/sender blocked");
                 return;
             default:
-                Log.v("Jasmine:Message Error!", "Unknown error");
+                Log.v("Jasmine:Message Error!", "Unknown error code=" + error);
         }
     }
 


### PR DESCRIPTION
## Summary
- clarify message error logging by including the unknown error code

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616898d36c83239b84a4b991b2b750