### PR TITLE
Handle ICQ message error 14

### DIFF
--- a/app/src/main/assets/locale/EN.txt
+++ b/app/src/main/assets/locale/EN.txt
@@ -208,6 +208,7 @@ s_reconnection_stop := Reconnection stopped
 s_reconnection_limit_exceed := Reconnection limit exceeded
 s_try_to_reconnect := Reconnection attempt #%%%1
 s_icq_authorize_text := Please authorize me
+s_icq_message_auth_required := Message not delivered. Authorization required
 s_jabber_error_code := Error code
 s_jabber_error_desc := Description
 s_jabber_error_dialog := %%%1 - error.[NL]%%%2

--- a/app/src/main/assets/locale/RU.txt
+++ b/app/src/main/assets/locale/RU.txt
@@ -208,6 +208,7 @@ s_reconnection_stop := Переподключение остановлено
 s_reconnection_limit_exceed := Превышен лимит переподключений
 s_try_to_reconnect := Попытка переподключения #%%%1
 s_icq_authorize_text := Пожалуйста, авторизуйте меня
+s_icq_message_auth_required := Сообщение не доставлено. Требуется авторизация
 s_jabber_error_code := Код ошибки
 s_jabber_error_desc := Описание
 s_jabber_error_dialog := %%%1 - ошибка.[NL]%%%2

--- a/app/src/main/assets/locale/UA.txt
+++ b/app/src/main/assets/locale/UA.txt
@@ -208,6 +208,7 @@ s_reconnection_stop := Перепідключення зупинено
 s_reconnection_limit_exceed := Перевищено ліміт перепідключення
 s_try_to_reconnect := Спроба перепідключення #%%%1
 s_icq_authorize_text := Будь ласка, авторизуйте мене
+s_icq_message_auth_required := Повідомлення не доставлено. Потрібна авторизація
 s_jabber_error_code := Код помилки
 s_jabber_error_desc := Опис
 s_jabber_error_dialog := %%%1 - Помилка.[NL]%%%2

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
@@ -1165,6 +1165,10 @@ public class ICQProfile extends IMProfile {
             case 16:
                 Log.v("Jasmine:Message Error!", "receiver/sender blocked");
                 return;
+            case 14:
+                Log.v("Jasmine:Message Error!", "authorization required to send message");
+                makeToast(resources.getString("s_icq_message_auth_required"));
+                return;
             default:
                 Log.v("Jasmine:Message Error!", "Unknown error code=" + error);
         }


### PR DESCRIPTION
## Summary
- handle error code 14 in ICQ message error handling
- add translations for "authorization required" message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686176b7bb248323b8a9b74c803dc457