### PR TITLE
Fix storage path for contacts

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -2290,7 +2290,12 @@ public class resources {
         am = ctx.getAssets();
         Locale.prepare();
         OS_VERSION = Integer.parseInt(android.os.Build.VERSION.SDK);
-        SD_PATH = Environment.getExternalStorageDirectory().getAbsolutePath();
+        File ext = ctx.getExternalFilesDir(null);
+        if (ext != null) {
+            SD_PATH = ext.getAbsolutePath();
+        } else {
+            SD_PATH = ctx.getFilesDir().getAbsolutePath();
+        }
         JASMINE_SD_PATH = SD_PATH + "/Jasmine/";
         JASMINE_INCOMING_FILES_PATH = JASMINE_SD_PATH + "RcvdFiles/";
         JASMINE_JHA_PATH = JASMINE_SD_PATH + "Jasmine History Archive/";


### PR DESCRIPTION
## Summary
- use `getExternalFilesDir` for `SD_PATH` instead of raw external storage path

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617c691d0c8323a0c800aa5482093f