### PR TITLE
Fix interrupted slide wrap handling

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -383,6 +383,16 @@ public class SlideSwitcher extends ViewGroup {
                 } else {
                     this.mIsBeingDragged = true;
                     this.scroller.forceFinished(true);
+                    if (this.wrap_mode) {
+                        if (this.wrap_direction < 0) {
+                            int width = getWidth() + this.DIVIDER_WIDTH;
+                            scrollTo((getChildCount() - 1) * width, 0);
+                            this.currentScreen = getChildCount() - 1;
+                        } else if (this.wrap_direction > 0) {
+                            scrollTo(0, 0);
+                            this.currentScreen = 0;
+                        }
+                    }
                     this.wrap_mode = false;
                     this.wrap_direction = 0;
                     setAnimationState(false);


### PR DESCRIPTION
## Summary
- handle wrap mode cancellation when touch begins mid-animation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861861a7478832383f331debc2a8b0b