### PR TITLE
Fix SlideSwitcher init

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -2064,7 +2064,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
         this.contactlist = new MultiColumnList(this, switcher.attrs);
         switcher.addView(this.chats_contactlist, resources.getString("s_cl_panel_chats"));
         switcher.addView(this.contactlist, resources.getString("s_cl_panel_contacts"));
-        switcher.attrs.recycle();
         switcher.scrollTo(1);
         resources.attachListSelector(this.chats_contactlist);
         resources.attachListSelector(this.contactlist);
@@ -2089,6 +2088,7 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
             resources.attachContactlistBack(this.contactlist);
         }
         checkConferences();
+        switcher.attrs.recycle();
         initToolsPanel();
     }
 


### PR DESCRIPTION
## Summary
- avoid reusing recycled `TypedArray` when adding conference panel

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686188cdfd4c8323a331a7fa03ee4f13