### PR TITLE
Fix MotionEvent cancel event handling

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -449,7 +449,10 @@ public class SlideSwitcher extends ViewGroup {
         if (!this.mIsBeingDragged) {
             return super.dispatchTouchEvent(event);
         }
-        super.dispatchTouchEvent(MotionEvent.obtain(event.getDownTime(), event.getEventTime(), MotionEvent.ACTION_CANCEL, event.getX(), event.getY(), 0));
+        MotionEvent cancel = MotionEvent.obtain(event);
+        cancel.setAction(MotionEvent.ACTION_CANCEL);
+        super.dispatchTouchEvent(cancel);
+        cancel.recycle();
         return true;
     }
 


### PR DESCRIPTION
## Summary
- ensure MotionEvent cancellation preserves pointer info

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619563f028832380b4b20f4daf84ef