### PR TITLE
Fix SlideSwitcher startup position and animation state

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -422,7 +422,7 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                 switcher.setAnimationType(PreferenceTable.ms_cl_transition_effect);
             }
             if (!PreferenceTable.ms_two_screens_mode) {
-                switcher.scrollTo(1);
+                switcher.post(() -> switcher.scrollTo(1));
             }
             SlideSwitcher slideSwitcher = switcher;
             if (PreferenceTable.ms_two_screens_mode) {
@@ -2064,7 +2064,7 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
         this.contactlist = new MultiColumnList(this, switcher.attrs);
         switcher.addView(this.chats_contactlist, resources.getString("s_cl_panel_chats"));
         switcher.addView(this.contactlist, resources.getString("s_cl_panel_contacts"));
-        switcher.scrollTo(1);
+        switcher.post(() -> switcher.scrollTo(1));
         resources.attachListSelector(this.chats_contactlist);
         resources.attachListSelector(this.contactlist);
         connectionStatusPanel = findViewById(R.id.profiles_connection_bars);

--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -770,6 +770,12 @@ public class SlideSwitcher extends ViewGroup {
     public void scrollTo(int screen) {
         int child_count = getChildCount();
         if (child_count > 0 && screen < child_count) {
+            if (!this.scroller.isFinished()) {
+                this.scroller.abortAnimation();
+            }
+            this.wrap_mode = false;
+            this.wrap_direction = 0;
+            setAnimationState(false);
             super.scrollTo((getWidth() + this.DIVIDER_WIDTH) * screen, 0);
             this.currentScreen = screen;
         }


### PR DESCRIPTION
## Summary
- ensure SlideSwitcher stops any active animation when jumping to a tab
- delay initial scrollTo call until layout is ready

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686197629cac832384eac3d3edab17d1