### PR TITLE
Fix slide switcher initial scroll and wrapping

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -292,6 +292,7 @@ public class SlideSwitcher extends ViewGroup {
             this.wrap_mode = false;
             this.wrap_direction = 0;
             setAnimationState(false);
+            postInvalidate();
         } else {
             setAnimationState(false);
         }
@@ -776,8 +777,13 @@ public class SlideSwitcher extends ViewGroup {
             this.wrap_mode = false;
             this.wrap_direction = 0;
             setAnimationState(false);
-            super.scrollTo((getWidth() + this.DIVIDER_WIDTH) * screen, 0);
-            this.currentScreen = screen;
+            if (getWidth() == 0) {
+                final int target = screen;
+                post(() -> scrollTo(target));
+            } else {
+                super.scrollTo((getWidth() + this.DIVIDER_WIDTH) * screen, 0);
+                this.currentScreen = screen;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update `SlideSwitcher.scrollTo` so calls before layout still work
- ensure `computeScroll` invalidates after wrapping

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a2aa14248323946d86b6593c7562