### PR TITLE
Fix SlideSwitcher scrolling bug

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -708,8 +708,8 @@ public class SlideSwitcher extends ViewGroup {
             this.wrap_direction = 0;
             setAnimationState(false);
             if (getWidth() == 0) {
-               /// final int target = screen;
-                post(() -> scrollTo(target));
+                final int scr = screen;
+                post(() -> scrollTo(scr));
             } else {
                 super.scrollTo((getWidth() + this.DIVIDER_WIDTH) * screen, 0);
                 this.currentScreen = screen;


### PR DESCRIPTION
## Summary
- ensure SlideSwitcher recursion uses screen index when width is zero

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a8cd74c083239a9800594346b838