### PR TITLE
Fix slide switcher alpha

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -258,6 +258,9 @@ public class SlideSwitcher extends ViewGroup {
             if (child != null) {
                 child.setDrawingCacheEnabled(false);
                 child.setWillNotCacheDrawing(true);
+                // Make sure hardware layers do not keep a faded copy
+                // of the view after the animation is finished
+                child.setAlpha(1f);
             }
         }
     }


### PR DESCRIPTION
## Summary
- reset alpha on children after slide animation completes

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ab352fa483239a6b814ffa4c0302