### PR TITLE
Enable translucent system bars on API 19+

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -221,6 +221,7 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
         }
         setVolumeControlStream(3);
         setContentView(R.layout.contactlist);
+        ru.ivansuper.jasmin.utils.SystemBarUtils.setupTransparentBars(this);
         service = resources.service;
         dialogs = new Vector<>();
         if (getResources().getConfiguration().orientation != 1) {

--- a/app/src/main/java/ru/ivansuper/jasmin/MainActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/MainActivity.java
@@ -40,6 +40,7 @@ public class MainActivity extends Activity implements Handler.Callback {
         super.onCreate(savedInstanceState);
         getWindowManager().getDefaultDisplay().getMetrics(resources.dm);
         setContentView(R.layout.activity_main);
+        ru.ivansuper.jasmin.utils.SystemBarUtils.setupTransparentBars(this);
 
         initializeViews();
 

--- a/app/src/main/java/ru/ivansuper/jasmin/utils/SystemBarUtils.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/utils/SystemBarUtils.java
@@ -1,0 +1,42 @@
+package ru.ivansuper.jasmin.utils;
+
+import android.app.Activity;
+import android.os.Build;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+
+public class SystemBarUtils {
+    public static void setupTransparentBars(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            Window window = activity.getWindow();
+            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+
+            final View root = activity.findViewById(android.R.id.content);
+            if (root == null) return;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+                root.setOnApplyWindowInsetsListener((v, insets) -> {
+                    v.setPadding(
+                            v.getPaddingLeft(),
+                            insets.getSystemWindowInsetTop(),
+                            v.getPaddingRight(),
+                            insets.getSystemWindowInsetBottom());
+                    return insets.consumeSystemWindowInsets();
+                });
+                root.requestApplyInsets();
+            } else {
+                int top = getInternalDimen(activity, "status_bar_height");
+                int bottom = getInternalDimen(activity, "navigation_bar_height");
+                root.setPadding(root.getPaddingLeft(), top, root.getPaddingRight(), bottom);
+            }
+        }
+    }
+
+    private static int getInternalDimen(Activity activity, String name) {
+        int resId = activity.getResources().getIdentifier(name, "dimen", "android");
+        return resId > 0 ? activity.getResources().getDimensionPixelSize(resId) : 0;
+    }
+}

--- a/app/src/main/res/values-v19/styles.xml
+++ b/app/src/main/res/values-v19/styles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="WallpaperNoTitleTheme" parent="@android:style/Theme.Wallpaper.NoTitleBar">
+        <item name="android:buttonStyle">@style/ButtonStyle</item>
+        <item name="android:editTextStyle">@style/EditTextStyle</item>
+        <item name="android:textViewStyle">@style/TextViewStyle</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+    </style>
+    <style name="BlackNoTitleTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:buttonStyle">@style/ButtonStyle</item>
+        <item name="android:editTextStyle">@style/EditTextStyle</item>
+        <item name="android:textViewStyle">@style/TextViewStyle</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- add utility for transparent status/nav bars
- enable translucent bars in main and contact list activities
- supply styles for API 19+ that turn on translucency

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b6fdc5a88323a7953b4f4e9bff51