### PR TITLE
Fix SlideSwitcher screen index update

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -307,6 +307,16 @@ public class SlideSwitcher extends ViewGroup {
             setAnimationState(false);
             postInvalidate();
         } else {
+            int width = getWidth() + DIVIDER_WIDTH;
+            int newScreen = Math.round((float) getScrollX() / width);
+            if (newScreen < 0) {
+                newScreen = 0;
+            }
+            int childCount = getChildCount();
+            if (childCount > 0 && newScreen >= childCount) {
+                newScreen = childCount - 1;
+            }
+            currentScreen = newScreen;
             setAnimationState(false);
         }
     }


### PR DESCRIPTION
## Summary
- update current screen when scrolling stops

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bc7991848323935c5e81d12458a7