### PR TITLE
Fix slide index persistence in SlideSwitcher

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -307,6 +307,18 @@ public class SlideSwitcher extends ViewGroup {
             setAnimationState(false);
             postInvalidate();
         } else {
+            int width = getWidth() + DIVIDER_WIDTH;
+            if (width > 0) {
+                int newScreen = Math.round((float) getScrollX() / width);
+                if (newScreen < 0) {
+                    newScreen = 0;
+                }
+                int childCount = getChildCount();
+                if (childCount > 0 && newScreen >= childCount) {
+                    newScreen = childCount - 1;
+                }
+                currentScreen = newScreen;
+            }
             setAnimationState(false);
         }
     }


### PR DESCRIPTION
## Summary
- update `computeScroll` to correctly update the current screen after animations

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon` *(fails: SDK location not found)*
- `./gradlew lintDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bc7991848323935c5e81d12458a7