### PR TITLE
Fix SlideSwitcher wrap mode not resetting

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -347,8 +347,14 @@ public class SlideSwitcher extends ViewGroup {
                 lastTouchX=accumulatedScrollX;
                 lastTouchY=ev.getY();
                 if (!scroller.isFinished()) {
-                    isDragging=true;
+                    isDragging = true;
                     scroller.forceFinished(true);
+                    if (wrapMode) {
+                        wrapMode = false;
+                        wrapDirection = 0;
+                        setAnimating(false);
+                        scrollTo(currentScreen * (getWidth() + dividerWidth), 0);
+                    }
                     return true;
                 }
                 break;


### PR DESCRIPTION
## Summary
- reset `wrapMode` when user interrupts an animation

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c81405948323a46f69ca278a604f