### PR TITLE
Fix SlideSwitcher scrolling issue

### DIFF
--- a/app/src/main/res/layout/contactlist.xml
+++ b/app/src/main/res/layout/contactlist.xml
@@ -37,13 +37,12 @@
                         android:focusable="true"
                         android:scrollbarThumbVertical="@drawable/scrollbar_thumb"
                         android:scrollbarTrackVertical="@drawable/scrollbar_track"
-                        android:scrollbars="vertical">
+                        android:scrollbars="vertical" />
 
-                        <ru.ivansuper.jasmin.ConfigListenerView
-                            android:id="@+id/config_listener"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent" />
-                    </ru.ivansuper.jasmin.slide_tools.SlideSwitcher>
+                    <ru.ivansuper.jasmin.ConfigListenerView
+                        android:id="@+id/config_listener"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent" />
 
                     <LinearLayout
                         android:id="@+id/profiles_connection_bars"


### PR DESCRIPTION
## Summary
- remove `ConfigListenerView` from inside `SlideSwitcher`
- place listener view alongside the switcher in the layout

This avoids an extra child inside `SlideSwitcher` that caused incorrect screen indexing and freezing when swiping.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864eeb3795483239643a2817fa3e434