### PR TITLE
Fix SlideSwitcher animation

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/slide_tools/SlideSwitcher.java
@@ -118,6 +118,9 @@ public class SlideSwitcher extends ViewGroup {
         setDrawingCacheEnabled(false);
         setWillNotCacheDrawing(true);
         setStaticTransformationsEnabled(true);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
+            setLayerType(LAYER_TYPE_SOFTWARE, null);
+        }
 
         // Label paint
         labelPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);


### PR DESCRIPTION
## Summary
- ensure SlideSwitcher uses software layer on new Android versions so transformations render correctly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f0e000848323bc9c25a9bf20ac7f