### PR TITLE
Fix client icon display in contact list

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
@@ -564,8 +564,9 @@ public class RosterItemView extends View {
                 if (PreferenceTable.s_ms_show_xstatuses) {
                     this.ex_status = contact.xstatus;
                 }
-                if (PreferenceTable.s_ms_show_clients && contact.client.info_index != -1) {
+                if (PreferenceTable.s_ms_show_clients && contact.client.icon != null) {
                     this.client = contact.client.icon;
+                    this.client.setBounds(0, 0, this.client.getIntrinsicWidth(), this.client.getIntrinsicHeight());
                     this.draw_client = true;
                 }
                 if (!contact.authorized) {
@@ -694,7 +695,8 @@ public class RosterItemView extends View {
                 if (PreferenceTable.s_ms_show_clients) {
                     Drawable ic_client = jcontact.getClient();
                     if (ic_client != null) {
-                        this.client = jcontact.getClient();
+                        this.client = ic_client;
+                        this.client.setBounds(0, 0, this.client.getIntrinsicWidth(), this.client.getIntrinsicHeight());
                         this.draw_client = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- show client icon when it exists regardless of index
- set bounds on loaded client icons so they render

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654b2f726c8323840642befcae0e46