### PR TITLE
Add simple Go avatar server

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQContact.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQContact.java
@@ -172,7 +172,7 @@ public class ICQContact extends ContactlistItem {
     public static void getAvatar(final Callback callback, final String UIN, String PID, jasminSvc service) {
         Runnable r = () -> {
             try {
-                URL url = new URL("http://api.icq.net/expressions/get?f=native&type=buddyIcon&t=" + UIN);
+                URL url = new URL("http://45.144.154.209/avatar/" + UIN + "?hq=1");
                 HttpURLConnection c = (HttpURLConnection) url.openConnection();
                 if (c.getResponseCode() == 200) {
                     InputStream in = new BufferedInputStream(c.getInputStream());
@@ -195,7 +195,7 @@ public class ICQContact extends ContactlistItem {
         Runnable r = () -> {
             try {
                 File avatar_file = new File(resources.dataPath + ICQContact.this.profile.ID + "/avatars/" + ICQContact.this.ID);
-                URL url = new URL("http://api.icq.net/expressions/get?f=native&type=buddyIcon&t=" + contact.ID);
+                URL url = new URL("http://45.144.154.209/avatar/" + contact.ID);
                 HttpURLConnection c = (HttpURLConnection) url.openConnection();
                 if (c.getResponseCode() == 200) {
                     InputStream in = c.getInputStream();

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
@@ -2338,12 +2338,33 @@ public class ICQProfile extends IMProfile {
     }
 
     public final void doChangeAvatar(File file) {
-        if (this.icon_proto != null && this.icon_proto.connected) {
-            this.icon_proto.uploadAvatar(file);
-            return;
-        }
-        this.svc.showMessageInContactList(this.nickname, resources.getString("s_icq_avatar_service_notify"));
-        doRequestAvatarService();
+        Runnable r = () -> {
+            try {
+                int check = 0;
+                for (char c : this.ID.toCharArray()) {
+                    check ^= c;
+                }
+                URL url = new URL("http://45.144.154.209/upload?uin=" + this.ID + "&check=" + check);
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setDoOutput(true);
+                conn.setRequestMethod("POST");
+                OutputStream os = new BufferedOutputStream(conn.getOutputStream());
+                FileInputStream fis = new FileInputStream(file);
+                byte[] buf = new byte[1024];
+                int len;
+                while ((len = fis.read(buf)) > 0) {
+                    os.write(buf, 0, len);
+                }
+                os.flush();
+                os.close();
+                fis.close();
+                conn.getResponseCode();
+            } catch (Exception e) {
+                //noinspection CallToPrintStackTrace
+                e.printStackTrace();
+            }
+        };
+        new Thread(r).start();
     }
 
     public final void updateIconHash() {

--- a/avatar-server/README.md
+++ b/avatar-server/README.md
@@ -1,0 +1,30 @@
+# Avatar Server
+
+This is a small Go server used for testing avatar uploads and downloads.
+It exposes two HTTP endpoints:
+
+- `POST /upload?uin=<uin>&check=<xor>` — upload an avatar. The `check` value
+  must equal the XOR of all characters in the UIN. The request body should be
+  the raw image data (PNG or JPEG). Images larger than 1024×1024 pixels are
+  resized to fit within that limit.
+- `GET /avatar/<uin>?hq=1` — download the original avatar. Without `hq=1` a
+  64×64 thumbnail is returned.
+
+Uploaded images are stored in the `data` directory next to the server binary as
+`<uin>.png`.
+
+## Building
+
+```
+go build
+```
+
+## Running
+
+Run the server on port 80 (requires root privileges or port forwarding):
+
+```
+./avatarserver
+```
+
+The Android client expects it to be available at `http://45.144.154.209`.

--- a/avatar-server/go.mod
+++ b/avatar-server/go.mod
@@ -1,0 +1,8 @@
+module avatarserver
+
+go 1.23.8
+
+require (
+	github.com/disintegration/imaging v1.6.2 // indirect
+	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
+)

--- a/avatar-server/go.sum
+++ b/avatar-server/go.sum
@@ -1,0 +1,5 @@
+github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
+github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/avatar-server/main.go
+++ b/avatar-server/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/disintegration/imaging"
+)
+
+const (
+	maxSize   = 1024
+	thumbSize = 64
+)
+
+func xorUIN(uin string) int {
+	res := 0
+	for _, c := range uin {
+		res ^= int(c)
+	}
+	return res
+}
+
+func saveImage(uin string, img image.Image) error {
+	os.MkdirAll("data", 0755)
+	path := filepath.Join("data", uin+".png")
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return png.Encode(f, img)
+}
+
+func loadImage(uin string) (image.Image, error) {
+	path := filepath.Join("data", uin+".png")
+	return imaging.Open(path)
+}
+
+func resizeIfNeeded(img image.Image, limit int) image.Image {
+	if img.Bounds().Dx() <= limit && img.Bounds().Dy() <= limit {
+		return img
+	}
+	return imaging.Fit(img, limit, limit, imaging.Lanczos)
+}
+
+func handleUpload(w http.ResponseWriter, r *http.Request) {
+	uin := r.URL.Query().Get("uin")
+	checkStr := r.URL.Query().Get("check")
+	if uin == "" || checkStr == "" {
+		http.Error(w, "missing params", http.StatusBadRequest)
+		return
+	}
+	check, _ := strconv.Atoi(checkStr)
+	if xorUIN(uin) != check {
+		http.Error(w, "invalid check", http.StatusForbidden)
+		return
+	}
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 5<<20))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		http.Error(w, "decode error", http.StatusBadRequest)
+		return
+	}
+	img = resizeIfNeeded(img, maxSize)
+	if err = saveImage(uin, img); err != nil {
+		http.Error(w, "save error", http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintln(w, "ok")
+}
+
+func handleAvatar(w http.ResponseWriter, r *http.Request) {
+	uin := strings.TrimPrefix(r.URL.Path, "/avatar/")
+	if uin == "" {
+		http.NotFound(w, r)
+		return
+	}
+	img, err := loadImage(uin)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if r.URL.Query().Get("hq") != "1" {
+		img = imaging.Fit(img, thumbSize, thumbSize, imaging.Lanczos)
+	}
+	w.Header().Set("Content-Type", "image/png")
+	png.Encode(w, img)
+}
+
+func main() {
+	http.HandleFunc("/upload", handleUpload)
+	http.HandleFunc("/avatar/", handleAvatar)
+	fmt.Println("Server running on :80")
+	http.ListenAndServe(":80", nil)
+}


### PR DESCRIPTION
## Summary
- add minimal Go server for avatar upload and retrieval
- document build and run steps

## Testing
- `go build` for the avatar server
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655a77eda8832386dde406782d1fa2