### PR TITLE
Fix menu button visibility

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
@@ -469,9 +469,6 @@ public class ICQChatActivity extends Chat {
             ICQChatActivity.this.removeDialog(1);
             ICQChatActivity.this.showDialog(1);
         });
-        if (!resources.IT_IS_TABLET) {
-            button.setVisibility(View.GONE);
-        }
         this.send = (Button) findViewById(R.id.send);
         this.send.setOnClickListener(new sndListener());
         this.input.addTextChangedListener(new el());

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/JConference.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/JConference.java
@@ -808,9 +808,6 @@ public class JConference extends Chat implements Handler.Callback {
             removeDialog(1);
             showDialog(1);
         });
-        if (!resources.IT_IS_TABLET) {
-            menuButton.setVisibility(View.GONE);
-        }
 
         // Send button
         send.setOnClickListener(new sndListener());

--- a/app/src/main/res/layout/contactlist.xml
+++ b/app/src/main/res/layout/contactlist.xml
@@ -158,14 +158,12 @@
 
                             <ImageView
                                 android:id="@+id/toggle_menu"
-                                android:layout_width="32dp"
-                                android:layout_height="wrap_content"
+                                android:layout_width="42dp"
+                                android:layout_height="42dp"
                                 android:layout_gravity="center"
-                                android:paddingStart="4dp"
-                                android:paddingLeft="4dp"
-                                android:paddingEnd="16dp"
-                                android:paddingRight="16dp"
-                                android:src="@drawable/contactlist_chat_divider" />
+                                android:padding="8dp"
+                                android:scaleType="fitXY"
+                                android:src="@drawable/ic_menu" />
                         </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>


### PR DESCRIPTION
## Summary
- keep chat menu button visible for phones
- use standard overflow icon for contact list menu button

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdfaeeeac8323a4a227101244ae43