### PR TITLE
Fix old Android crash by adding Objects stub

### DIFF
--- a/app/src/main/java/java/util/Objects.java
+++ b/app/src/main/java/java/util/Objects.java
@@ -1,0 +1,43 @@
+package java.util;
+
+/**
+ * Minimal backport of java.util.Objects for API levels lacking this class.
+ */
+public final class Objects {
+    private Objects() {}
+
+    public static <T> T requireNonNull(T obj) {
+        if (obj == null) throw new NullPointerException();
+        return obj;
+    }
+
+    public static <T> T requireNonNull(T obj, String message) {
+        if (obj == null) throw new NullPointerException(message);
+        return obj;
+    }
+
+    public static boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+
+    public static int hash(Object... values) {
+        if (values == null) return 0;
+        int result = 1;
+        for (Object element : values) {
+            result = 31 * result + (element == null ? 0 : element.hashCode());
+        }
+        return result;
+    }
+
+    public static int hashCode(Object o) {
+        return o != null ? o.hashCode() : 0;
+    }
+
+    public static String toString(Object o) {
+        return String.valueOf(o);
+    }
+
+    public static String toString(Object o, String nullDefault) {
+        return o != null ? o.toString() : nullDefault;
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal `java.util.Objects` implementation for compatibility with Android 2.3.6

## Testing
- `./gradlew --version`
- *(build commands failed due to unsupported JDK)*

------
https://chatgpt.com/codex/tasks/task_e_686cd453180c8323bce1d945e7736ee5