### PR TITLE
Hide on screen menu when device has hardware key

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -271,7 +271,11 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
             checkPwd();
         }
 
-        findViewById(R.id.toggle_menu).setOnClickListener(new View.OnClickListener() {
+        View menuToggle = findViewById(R.id.toggle_menu);
+        if (utilities.hasHardwareMenuKey(this)) {
+            menuToggle.setVisibility(View.GONE);
+        }
+        menuToggle.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 handleMenuKey();

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
@@ -466,6 +466,9 @@ public class ICQChatActivity extends Chat {
         this.input = (EditText) findViewById(R.id.input);
         this.input.setTextSize(PreferenceTable.chatTextSize);
         Button button = (Button) findViewById(R.id.chat_menu_btn);
+        if (utilities.hasHardwareMenuKey(this)) {
+            button.setVisibility(View.GONE);
+        }
         resources.attachButtonStyle(button);
         button.setCompoundDrawables(resources.chat_menu_icon, null, null, null);
         button.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/JConference.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/JConference.java
@@ -863,6 +863,9 @@ public class JConference extends Chat implements Handler.Callback {
         TOP_PANEL = (LinearLayout) findViewById(R.id.chat_header);
         LinearLayout bottomPanel = (LinearLayout) findViewById(R.id.chat_bottom_panel);
         Button menuButton = (Button) findViewById(R.id.chat_menu_btn);
+        if (utilities.hasHardwareMenuKey(this)) {
+            menuButton.setVisibility(View.GONE);
+        }
 
         // User toggle button
         mUsersToggleButton.setBackgroundColor(ColorScheme.divideAlpha(ColorScheme.getColor(48), 2));

--- a/app/src/main/java/ru/ivansuper/jasmin/utilities.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/utilities.java
@@ -5,6 +5,9 @@ import android.text.style.ClickableSpan;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewConfiguration;
+import android.os.Build;
+import android.content.Context;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 
@@ -667,6 +670,18 @@ public class utilities {
         int minutes = seconds / 60;
         int secs = seconds % 60;
         return normalizeStringLength(String.valueOf(minutes), "0", 2) + ":" + normalizeStringLength(String.valueOf(secs), "0", 2);
+    }
+
+    /**
+     * Check if device has a hardware menu key.
+     * For pre-ICS devices we assume menu key is present.
+     */
+    public static boolean hasHardwareMenuKey(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            ViewConfiguration config = ViewConfiguration.get(context);
+            return config.hasPermanentMenuKey();
+        }
+        return true;
     }
 
     public static String normalizeStringLength(String src, String char_, int length) {


### PR DESCRIPTION
## Summary
- add `hasHardwareMenuKey` utility
- hide menu buttons when hardware menu key exists
- hide contact list menu toggle when hardware menu key exists

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686cebc936b88323ad2d621a387aaa07