### PR TITLE
Fix client icon display on newer Android

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
@@ -566,6 +566,9 @@ public class RosterItemView extends View {
                 }
                 if (PreferenceTable.s_ms_show_clients && contact.client.info_index != -1) {
                     this.client = contact.client.icon;
+                    if (this.client != null && this.client.getBounds().isEmpty()) {
+                        this.client.setBounds(0, 0, this.client.getIntrinsicWidth(), this.client.getIntrinsicHeight());
+                    }
                     this.draw_client = true;
                 }
                 if (!contact.authorized) {
@@ -694,7 +697,10 @@ public class RosterItemView extends View {
                 if (PreferenceTable.s_ms_show_clients) {
                     Drawable ic_client = jcontact.getClient();
                     if (ic_client != null) {
-                        this.client = jcontact.getClient();
+                        this.client = ic_client;
+                        if (this.client.getBounds().isEmpty()) {
+                            this.client.setBounds(0, 0, this.client.getIntrinsicWidth(), this.client.getIntrinsicHeight());
+                        }
                         this.draw_client = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure client icons have bounds before drawing

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686cf659fe4c8323bdc7bc34bc1e7c17