### PR TITLE
Fix conference tab not visible after adding Jabber profile

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -495,6 +495,9 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
             initToolsPanel();
             service.cancelMultiloginNotify();
             service.handleContactlistNeedRemake();
+            // ensure conference tab state is up to date when returning from
+            // ProfilesActivity or other screens
+            checkConferences();
         }
         HIDDEN = false;
         checkForBufferedDialogs();


### PR DESCRIPTION
## Summary
- keep conference tab updated on resume

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686cf7ba45c8832395bb76f9b08beea5