### PR TITLE
Fix conferences screen hidden after adding Jabber profile

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -495,6 +495,9 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
             initToolsPanel();
             service.cancelMultiloginNotify();
             service.handleContactlistNeedRemake();
+            // ensure conference tab state is up to date when returning from
+            // ProfilesActivity or other screens
+            checkConferences();
         }
         HIDDEN = false;
         checkForBufferedDialogs();
@@ -2478,6 +2481,9 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
         if (service != null && service.profiles != null) {
             try {
                 boolean confs_present = service.profiles.scanForConferences();
+                if (!confs_present) {
+                    confs_present = service.profiles.hasEnabledJabberProfile();
+                }
                 if (confs_present && this.confs_contactlist == null) {
                     this.confs_contactlist = new MultiColumnList(this);
                     resources.attachListSelector(this.confs_contactlist);

--- a/app/src/main/java/ru/ivansuper/jasmin/ProfilesManager.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ProfilesManager.java
@@ -445,6 +445,20 @@ public class ProfilesManager {
         return list;
     }
 
+    /**
+     * Check if there is at least one enabled Jabber profile.
+     */
+    public final boolean hasEnabledJabberProfile() {
+        int len = this.profiles.size();
+        for (int i = 0; i < len; i++) {
+            IMProfile profile = this.profiles.get(i);
+            if (profile.profile_type == 1 && profile.enabled) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public final boolean scanForConferences() {
         int len = this.profiles.size();
         for (int i = 0; i < len; i++) {


### PR DESCRIPTION
## Summary
- expose new method `ProfilesManager.hasEnabledJabberProfile`
- show conference tab whenever at least one Jabber profile is enabled

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686cf7ba45c8832395bb76f9b08beea5