### PR TITLE
Fix strict JID validation

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
@@ -119,10 +119,11 @@ public class JProfile extends IMProfile {
     private boolean roster_received = false;
 
     private static boolean isValidJid(String jid) {
-        if (jid == null || jid.isEmpty()) {
+        if (jid == null) {
             return false;
         }
-        return jid.matches("[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+");
+        int atPos = jid.indexOf('@');
+        return atPos > 0 && atPos < jid.length() - 1;
     }
 
     private void putMessage(Node node) {


### PR DESCRIPTION
## Summary
- relax JID validation to support non-ASCII room names

## Testing
- `../gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686cfee574088323bb0da9f0f085dfad