### PR TITLE
Fix NPE when creating Conference

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/conference/Conference.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/conference/Conference.java
@@ -42,7 +42,7 @@ public class Conference {
     public String pass;
     public JProfile profile;
     /** @noinspection unused*/
-    private final String SCROLL_STATE_HASH = Integer.toHexString(utilities.getHash(this));
+    private final String SCROLL_STATE_HASH;
     public String theme = "";
     public ArrayList<HistoryItem> history = new ArrayList<>();
     public String typedText = "";
@@ -56,6 +56,7 @@ public class Conference {
         this.nick = nick;
         this.pass = pass;
         this.profile = profile;
+        this.SCROLL_STATE_HASH = Integer.toHexString(utilities.getHash(this));
     }
 
     public final void registerPMContact(JContact contact) {


### PR DESCRIPTION
## Summary
- fix NPE caused by computing `SCROLL_STATE_HASH` before the `profile` field is set

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686d00e7a1c483238805320a898adb96