### PR TITLE
Fix client icon scaling on high density devices

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -2195,8 +2195,13 @@ public class resources {
                 return 24;
             case DisplayMetrics.DENSITY_HIGH:
                 return 32;
+            case DisplayMetrics.DENSITY_XHIGH:
+                return 48;
+            case DisplayMetrics.DENSITY_XXHIGH:
+            case DisplayMetrics.DENSITY_XXXHIGH:
+                return 64;
             default:
-                return -1; // Use the original size for other densities
+                return 32; // Fallback for other densities
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust icon scaling for xhdpi and higher density screens so client icons display on Android 15

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686d087a256883239fba5b4ee78771d2