### PR TITLE
Fix MD5 auth packet

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProtocol.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProtocol.java
@@ -88,14 +88,65 @@ public class ICQProtocol {
         return FLAP.createFlap((byte) 2, seq, snc);
     }
 
+    /**
+     * Build login packet for the SNAC based MD5 authorization sequence.
+     * This follows the layout described in the OSCAR 2003 specification and is
+     * similar to the XOR login TLV set but uses the MD5 hash (TLV 0x25).
+     */
     public static ByteBuffer createMD5Login(byte[] key, int seq, String uin, String password) throws Exception {
-        ByteBuffer buffer = new ByteBuffer(512);
-        buffer.writeWord(1);
+        ByteBuffer buffer = new ByteBuffer(ContactListActivity.UPDATE_BLINK_STATE + CLIENT_STRING.length());
+
+        buffer.writeWord(0x01);
         buffer.writePreLengthStringAscii(uin);
-        buffer.writeWord(37);
+
+        buffer.writeWord(0x25);
         byte[] md5 = utilities.getHashArray(key, password);
         buffer.writeWord(md5.length);
         buffer.write(md5);
+
+        // Indicate use of the newer MD5 method
+        buffer.writeWord(0x4C);
+        buffer.writeWord(0);
+
+        buffer.writeWord(0x03);
+        buffer.writePreLengthStringAscii(CLIENT_STRING);
+
+        buffer.writeWord(0x16);
+        buffer.writeWord(TLV_0X16_DATA.length);
+        buffer.write(TLV_0X16_DATA);
+
+        buffer.writeWord(0x17);
+        buffer.writeWord(TLV_0X17_MAJOR.length);
+        buffer.write(TLV_0X17_MAJOR);
+
+        buffer.writeWord(0x18);
+        buffer.writeWord(TLV_0X18_MINOR.length);
+        buffer.write(TLV_0X18_MINOR);
+
+        buffer.writeWord(0x19);
+        buffer.writeWord(TLV_0X19_LESSER.length);
+        buffer.write(TLV_0X19_LESSER);
+
+        buffer.writeWord(0x1A);
+        buffer.writeWord(TLV_0X1A_BUILD.length);
+        buffer.write(TLV_0X1A_BUILD);
+
+        buffer.writeWord(0x14);
+        buffer.writeWord(4);
+        buffer.writeDWord(TLV_0X14_DISTRIBUTION);
+
+        buffer.writeWord(0x0F);
+        buffer.writeWord(TLV_LANGUAGE.length());
+        buffer.writeStringAscii(TLV_LANGUAGE);
+
+        buffer.writeWord(0x0E);
+        buffer.writeWord(TLV_COUNTRY.length());
+        buffer.writeStringAscii(TLV_COUNTRY);
+
+        buffer.writeWord(0x4A);
+        buffer.writeWord(1);
+        buffer.writeByte((byte) 0x01);
+
         ByteBuffer snc = SNAC.createSnac(23, 2, 0, 0, buffer);
         return FLAP.createFlap((byte) 2, seq, snc);
     }
@@ -111,7 +162,7 @@ public class ICQProtocol {
         buffer.writeWord(1);
         buffer.writePreLengthStringAscii(uin);
         buffer.writeWord(0x25);
-        byte[] md5 = utilities.getHashArray(key, pass);
+        byte[] md5 = utilities.getOldHashArray(key, pass);
         buffer.writeWord(md5.length);
         buffer.write(md5);
 

--- a/app/src/main/java/ru/ivansuper/jasmin/utilities.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/utilities.java
@@ -119,6 +119,19 @@ public class utilities {
      */
     public static byte[] getHashArray(byte[] key, String password) throws Exception {
         //noinspection InjectedReferences
+        byte[] passDigest = MD5.calculateMD5(password.getBytes("windows1251"));
+        byte[] md5buf = new byte[key.length + passDigest.length + MD5.AIM_MD5_STRING.length];
+        System.arraycopy(key, 0, md5buf, 0, key.length);
+        int md5marker = key.length;
+        System.arraycopy(passDigest, 0, md5buf, md5marker, passDigest.length);
+        System.arraycopy(MD5.AIM_MD5_STRING, 0, md5buf, md5marker + passDigest.length, MD5.AIM_MD5_STRING.length);
+        return MD5.calculateMD5(md5buf);
+    }
+
+    /**
+     * Calculate legacy MD5 hash used by older OSCAR implementations.
+     */
+    public static byte[] getOldHashArray(byte[] key, String password) throws Exception {
         byte[] passwordRaw = password.getBytes("windows1251");
         byte[] md5buf = new byte[key.length + passwordRaw.length + MD5.AIM_MD5_STRING.length];
         System.arraycopy(key, 0, md5buf, 0, key.length);


### PR DESCRIPTION
## Summary
- build proper TLV set for MD5 login so OSCAR server can authenticate
- support both new and legacy MD5 hashing

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686d8bf3a1008323b776792ca68be39c