### PR TITLE
Fix order of MD5 auth methods

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,14 +2,14 @@
 <resources>
     <string-array name="auth_methods">
         <item>Plain XOR</item>
-        <item>MD5</item>
         <item>MD5 Old</item>
+        <item>MD5</item>
         <item>HTTP</item>
     </string-array>
     <string-array name="auth_methods_values">
         <item>0</item>
-        <item>1</item>
         <item>3</item>
+        <item>1</item>
         <item>2</item>
     </string-array>
     <string-array name="smileys_scale_labels">


### PR DESCRIPTION
## Summary
- swap MD5 and MD5 Old labels in auth methods list

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686d97c43b788323ae1e84209c6a9dd1