### PR TITLE
Fix TLS trust store

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
@@ -481,6 +481,7 @@ public class JProfile extends IMProfile {
             Log.e("JABBER", "SSL/TLS enabled!");
             this.tls_enabled = true;
             this.stream.jumpToSSL(this.server, 5222);
+            System.clearProperty("javax.net.ssl.trustStore");
         }
     }
 


### PR DESCRIPTION
## Summary
- clear custom trust store value after switching to TLS

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686da342a5408323bc31cae37d5af370