### PR TITLE
Add basic IRC profile support

### DIFF
--- a/app/src/main/assets/locale/EN.txt
+++ b/app/src/main/assets/locale/EN.txt
@@ -409,6 +409,10 @@ s_vk_dialog_login := id***... or Nickname
 s_ya_dialog_login := Your E-Mail
 s_qip_dialog_login := Login
 s_gtalk_dialog_login := Your E-Mail
+s_irc_dialog_server := IRC server
+s_irc_dialog_port := Port
+s_irc_dialog_nick := Nickname
+s_profile_type_irc := IRC
 //=============================
 //Contactlist
 //=============================

--- a/app/src/main/assets/locale/RU.txt
+++ b/app/src/main/assets/locale/RU.txt
@@ -409,6 +409,10 @@ s_vk_dialog_login := id***... или Nickname
 s_ya_dialog_login := Ваш E-Mail
 s_qip_dialog_login := Логин
 s_gtalk_dialog_login := Ваш E-Mail
+s_irc_dialog_server := Сервер IRC
+s_irc_dialog_port := Порт
+s_irc_dialog_nick := Ник
+s_profile_type_irc := IRC
 //=============================
 //Contactlist
 //=============================

--- a/app/src/main/assets/locale/UA.txt
+++ b/app/src/main/assets/locale/UA.txt
@@ -409,6 +409,10 @@ s_vk_dialog_login := id***... або Nickname
 s_ya_dialog_login := Ваш E-Mail
 s_qip_dialog_login := Логін
 s_gtalk_dialog_login := Ваш E-Mail
+s_irc_dialog_server := Сервер IRC
+s_irc_dialog_port := Порт
+s_irc_dialog_nick := Нік
+s_profile_type_irc := IRC
 //=============================
 //Contactlist
 //=============================

--- a/app/src/main/java/ru/ivansuper/jasmin/ProfilesActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ProfilesActivity.java
@@ -228,6 +228,10 @@ public class ProfilesActivity extends Activity {
                                         removeDialog(12);
                                         showDialog(12);
                                         return;
+                                    case 3:
+                                        removeDialog(18);
+                                        showDialog(18);
+                                        return;
                                     default:
                                         return;
                                 }
@@ -320,6 +324,7 @@ public class ProfilesActivity extends Activity {
                 adp.put(this.service.getResources().getDrawable(R.drawable.ya_online), resources.getString("s_profile_type_yandex"), 3);
                 adp.put(this.service.getResources().getDrawable(R.drawable.qip_online), resources.getString("s_profile_type_qip"), 5);
                 adp.put(this.service.getResources().getDrawable(R.drawable.gtalk_online), resources.getString("s_profile_type_gtalk"), 6);
+                adp.put(this.service.getResources().getDrawable(R.drawable.xmpp_online), resources.getString("s_profile_type_irc"), 7);
                 //noinspection UnnecessaryLocalVariable
                 Dialog ad5 = DialogBuilder.create(this, resources.getString("s_add_profile"), adp, new AdapterView.OnItemClickListener() {
                     @Override
@@ -353,6 +358,10 @@ public class ProfilesActivity extends Activity {
                             case 6:
                                 removeDialog(15);
                                 showDialog(15);
+                                return;
+                            case 7:
+                                removeDialog(17);
+                                showDialog(17);
                                 return;
                             default:
                         }
@@ -1178,6 +1187,94 @@ public class ProfilesActivity extends Activity {
                     }
                 });
                 return ad17;
+            case 17:
+                @SuppressLint("InflateParams")
+                LinearLayout layIrcAdd = (LinearLayout) LayoutInflater.from(this).inflate(R.layout.irc_profile_add, null);
+                ((TextView) layIrcAdd.findViewById(R.id.l1)).setText(resources.getString("s_irc_dialog_server"));
+                ((TextView) layIrcAdd.findViewById(R.id.l2)).setText(resources.getString("s_irc_dialog_port"));
+                ((TextView) layIrcAdd.findViewById(R.id.l3)).setText(resources.getString("s_irc_dialog_nick"));
+                final EditText ircServer = layIrcAdd.findViewById(R.id.irc_profile_add_server);
+                resources.attachEditText(ircServer);
+                final EditText ircPort = layIrcAdd.findViewById(R.id.irc_profile_add_port);
+                resources.attachEditText(ircPort);
+                final EditText ircNick = layIrcAdd.findViewById(R.id.irc_profile_add_nick);
+                resources.attachEditText(ircNick);
+                final CheckBox ircEnabled = layIrcAdd.findViewById(R.id.irc_profile_add_enabled);
+                ircEnabled.setText(Locale.getString("s_profile_enabled"));
+                final CheckBox ircAutoconnect = layIrcAdd.findViewById(R.id.irc_profile_add_autoconnect);
+                ircAutoconnect.setText(resources.getString("s_dialog_autologin"));
+                Dialog adIrcAdd = DialogBuilder.createYesNo(this, layIrcAdd, 48, resources.getString("s_profile_adding"), resources.getString("s_do_add"), resources.getString("s_cancel"), new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        ProfilesAdapterItem pdata = new ProfilesAdapterItem();
+                        pdata.profile_type = 3;
+                        pdata.server = ircServer.getText().toString().trim();
+                        try { pdata.port = Integer.parseInt(ircPort.getText().toString().trim()); } catch (Exception e) { pdata.port = 6667; }
+                        pdata.id = ircNick.getText().toString().trim();
+                        pdata.enabled = ircEnabled.isChecked();
+                        pdata.autoconnect = ircAutoconnect.isChecked();
+                        pa.add(pdata);
+                        ru.ivansuper.jasmin.irc.IRCProfile profile = new ru.ivansuper.jasmin.irc.IRCProfile(pdata.server, pdata.port, pdata.id);
+                        profile.autoconnect = pdata.autoconnect;
+                        profile.enabled = pdata.enabled;
+                        service.profiles.addProfile(profile);
+                        service.profiles.writeProfilesToFile();
+                        service.handleProfileChanged();
+                        service.handleContactlistNeedRemake();
+                        removeDialog(17);
+                    }
+                }, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        removeDialog(17);
+                    }
+                });
+                return adIrcAdd;
+            case 18:
+                @SuppressLint("InflateParams")
+                LinearLayout layIrcEdit = (LinearLayout) LayoutInflater.from(this).inflate(R.layout.irc_profile_add, null);
+                ((TextView) layIrcEdit.findViewById(R.id.l1)).setText(resources.getString("s_irc_dialog_server"));
+                ((TextView) layIrcEdit.findViewById(R.id.l2)).setText(resources.getString("s_irc_dialog_port"));
+                ((TextView) layIrcEdit.findViewById(R.id.l3)).setText(resources.getString("s_irc_dialog_nick"));
+                final EditText ircServerE = layIrcEdit.findViewById(R.id.irc_profile_add_server);
+                resources.attachEditText(ircServerE);
+                final EditText ircPortE = layIrcEdit.findViewById(R.id.irc_profile_add_port);
+                resources.attachEditText(ircPortE);
+                final EditText ircNickE = layIrcEdit.findViewById(R.id.irc_profile_add_nick);
+                resources.attachEditText(ircNickE);
+                final CheckBox ircEnabledE = layIrcEdit.findViewById(R.id.irc_profile_add_enabled);
+                ircEnabledE.setText(Locale.getString("s_profile_enabled"));
+                final CheckBox ircAutoconnectE = layIrcEdit.findViewById(R.id.irc_profile_add_autoconnect);
+                ircAutoconnectE.setText(resources.getString("s_dialog_autologin"));
+                ircServerE.setText(pa.getItem(selectedIdx).server);
+                ircPortE.setText(String.valueOf(pa.getItem(selectedIdx).port));
+                ircNickE.setText(pa.getItem(selectedIdx).id);
+                ircEnabledE.setChecked(pa.getItem(selectedIdx).enabled);
+                ircAutoconnectE.setChecked(pa.getItem(selectedIdx).autoconnect);
+                Dialog adIrcEdit = DialogBuilder.createYesNo(this, layIrcEdit, 48, resources.getString("s_profile_changing"), resources.getString("s_change"), resources.getString("s_cancel"), new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        ProfilesAdapterItem pdata = pa.getItem(selectedIdx);
+                        pdata.profile_type = 3;
+                        pdata.server = ircServerE.getText().toString().trim();
+                        try { pdata.port = Integer.parseInt(ircPortE.getText().toString().trim()); } catch (Exception e) { pdata.port = 6667; }
+                        pdata.id = ircNickE.getText().toString().trim();
+                        pdata.enabled = ircEnabledE.isChecked();
+                        pdata.autoconnect = ircAutoconnectE.isChecked();
+                        pa.notifyDataSetChanged();
+                        ((ru.ivansuper.jasmin.irc.IRCProfile) service.profiles.getProfiles().get(selectedIdx)).reinitParams(pdata);
+                        service.profiles.writeProfilesToFile();
+                        service.handleProfileChanged();
+                        service.handleContactlistNeedRemake();
+                        removeDialog(18);
+                    }
+                }, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        removeDialog(18);
+                    }
+                });
+                return adIrcEdit;
             default:
                 return null;
         }
@@ -1236,6 +1333,15 @@ public class ProfilesActivity extends Activity {
                     pdata.id = mmp_profile.ID;
                     pdata.pass = mmp_profile.PASS;
                     pdata.autoconnect = mmp_profile.autoconnect;
+                    pdatas.add(pdata);
+                    break;
+                case 3:
+                    ru.ivansuper.jasmin.irc.IRCProfile irc = (ru.ivansuper.jasmin.irc.IRCProfile) improfile;
+                    pdata.profile_type = 3;
+                    pdata.server = irc.server;
+                    pdata.port = irc.port;
+                    pdata.id = irc.nickname;
+                    pdata.autoconnect = irc.autoconnect;
                     pdatas.add(pdata);
                     break;
             }

--- a/app/src/main/java/ru/ivansuper/jasmin/ProfilesAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ProfilesAdapter.java
@@ -80,6 +80,9 @@ public class ProfilesAdapter extends BaseAdapter {
             case 2:
                 icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.mrim_contact_status_online));
                 break;
+            case 3:
+                icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.xmpp_online));
+                break;
         }
         item.addView(icon);
         item.addView(label);

--- a/app/src/main/java/ru/ivansuper/jasmin/irc/IRCProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/irc/IRCProfile.java
@@ -168,4 +168,18 @@ public class IRCProfile extends IMProfile {
     public void setStatusText(String str) {
         // IRC has no status text
     }
+
+    /**
+     * Update profile parameters from adapter data
+     */
+    public void reinitParams(ru.ivansuper.jasmin.ProfilesAdapterItem pdata) {
+        this.server = pdata.server;
+        this.port = pdata.port;
+        this.nickname = pdata.id;
+        this.autoconnect = pdata.autoconnect;
+        this.enabled = pdata.enabled;
+        if (!this.enabled && this.connected) {
+            disconnect();
+        }
+    }
 }

--- a/app/src/main/res/layout/irc_profile_add.xml
+++ b/app/src/main/res/layout/irc_profile_add.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="10sp">
+
+    <TextView
+        android:id="@+id/l1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Server:"
+        android:textColor="#ffffffff"
+        android:textSize="20sp" />
+
+    <EditText
+        android:id="@+id/irc_profile_add_server"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <requestFocus />
+    </EditText>
+
+    <TextView
+        android:id="@+id/l2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Port:"
+        android:textColor="#ffffffff"
+        android:textSize="20sp" />
+
+    <EditText
+        android:id="@+id/irc_profile_add_port"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="numberDecimal"
+        android:maxLength="5"
+        android:text="6667" />
+
+    <TextView
+        android:id="@+id/l3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nickname:"
+        android:textColor="#ffffffff"
+        android:textSize="20sp" />
+
+    <EditText
+        android:id="@+id/irc_profile_add_nick"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <ru.ivansuper.jasmin.ui.MCheckBox
+        android:id="@+id/irc_profile_add_enabled"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="Enabled" />
+
+    <ru.ivansuper.jasmin.ui.MCheckBox
+        android:id="@+id/irc_profile_add_autoconnect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Autoconnect" />
+</LinearLayout>

--- a/app/src/main/res/values/public.xml
+++ b/app/src/main/res/values/public.xml
@@ -297,7 +297,8 @@
     <public name="xmpp_reg_form" id="0x7f03003d" type="layout" />
     <public name="xmpp_vk_profile_add" id="0x7f03003e" type="layout" />
     <public name="xmpp_ya_profile_add" id="0x7f03003f" type="layout" />
-    <public name="xtraz_dialog" id="0x7f030040" type="layout" />
+    <public name="irc_profile_add" id="0x7f030040" type="layout" />
+    <public name="xtraz_dialog" id="0x7f030041" type="layout" />
     <public name="center_dialog_hide" id="0x7f040000" type="anim" />
     <public name="center_dialog_show" id="0x7f040001" type="anim" />
     <public name="top_dialog_hide" id="0x7f040002" type="anim" />
@@ -644,4 +645,9 @@
     <public name="xmpp_profile_add_sasl" id="0x7f0b0132" type="id" />
     <public name="xtraz_title" id="0x7f0b0133" type="id" />
     <public name="xtraz_text" id="0x7f0b0134" type="id" />
+    <public name="irc_profile_add_server" id="0x7f0b0135" type="id" />
+    <public name="irc_profile_add_port" id="0x7f0b0136" type="id" />
+    <public name="irc_profile_add_nick" id="0x7f0b0137" type="id" />
+    <public name="irc_profile_add_enabled" id="0x7f0b0138" type="id" />
+    <public name="irc_profile_add_autoconnect" id="0x7f0b0139" type="id" />
 </resources>


### PR DESCRIPTION
## Summary
- add strings for IRC profile management in all locales
- add layout for IRC profile input
- handle IRC profiles in `ProfilesActivity` and adapter
- support updating IRC profile parameters
- register layout/IDs in public resources

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_687fb43f39508323954f20cb260aaed6