### PR TITLE
Add IRC bottom panel icon support

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -3574,6 +3574,67 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                         });
                         profilesPanel.addView(status1);
                         break;
+                    case 3:
+                        final ru.ivansuper.jasmin.irc.IRCProfile ircProfile = (ru.ivansuper.jasmin.irc.IRCProfile) improfile;
+                        final ImageView statusIrc = new ImageView(this);
+                        statusIrc.setClickable(true);
+                        statusIrc.setPadding(8, 7, 8, 7);
+                        statusIrc.setLayoutParams(new ViewGroup.LayoutParams(sizeInPixels, sizeInPixels));
+                        statusIrc.setBackgroundDrawable(resources.getListSelector());
+                        statusIrc.setOnClickListener(new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                                contextProfile = ircProfile;
+                                UAdapter list2 = new UAdapter();
+                                list2.setTextSize(18);
+                                list2.setPadding(5);
+                                if (ircProfile.connected || ircProfile.connecting) {
+                                    list2.put(resources.offline, resources.getString("s_status_offline"), 1);
+                                } else {
+                                    list2.put(resources.online, resources.getString("s_status_online"), 0);
+                                }
+                                last_quick_action = PopupBuilder.buildList(list2, view, ircProfile.nickname, RETURN_TO_CONTACTS, -2, new AdapterView.OnItemClickListener() {
+                                    @Override
+                                    public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                                        last_quick_action.dismiss();
+                                        if (i == 0) {
+                                            if (!ircProfile.connected && !ircProfile.connecting) {
+                                                ircProfile.startConnecting();
+                                            }
+                                        } else if (i == 1) {
+                                            ircProfile.disconnect();
+                                        }
+                                    }
+                                });
+                                last_quick_action.show();
+                            }
+                        });
+                        profilesPanel.addView(statusIrc);
+                        ircProfile.setNotifier(new IMProfile.BottomPanelNotifier() {
+                            @Override
+                            public void onStatusChanged() {
+                                if (ircProfile.connected) {
+                                    statusIrc.setImageDrawable(resources.irc_online);
+                                } else if (ircProfile.connecting) {
+                                    statusIrc.setImageDrawable(resources.irc_connecting);
+                                } else {
+                                    statusIrc.setImageDrawable(resources.irc_offline);
+                                }
+                            }
+
+                            @Override
+                            public void onConnectionStatusChanged() {
+                                if (improfile.connection_status > 0 && improfile.connection_status < 100) {
+                                    cbLine.setVisibility(View.VISIBLE);
+                                    cbLabel.setText(improfile.ID);
+                                    cbProgress.setProgress(improfile.connection_status);
+                                } else {
+                                    cbLine.setVisibility(View.GONE);
+                                }
+                                checkConnectionPanelVisibility();
+                            }
+                        });
+                        break;
                 }
                 //boolean a = SNAC.sts.startsWith(utilities.randomized);
                 //int zzs = Math.abs(245);

--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -298,6 +298,9 @@ public class resources {
     public static Drawable yandex_connecting;
     public static Drawable yandex_offline;
     public static Drawable yandex_online;
+    public static Drawable irc_connecting;
+    public static Drawable irc_offline;
+    public static Drawable irc_online;
 
     public resources() {
     }
@@ -1310,6 +1313,18 @@ public class resources {
             yandex_connecting = normalize(res.getDrawable(R.drawable.ya_connecting));
         }
 
+        if (irc_online == null) {
+            irc_online = normalize(res.getDrawable(R.drawable.irc_online));
+        }
+
+        if (irc_offline == null) {
+            irc_offline = normalize(res.getDrawable(R.drawable.irc_offline));
+        }
+
+        if (irc_connecting == null) {
+            irc_connecting = normalize(res.getDrawable(R.drawable.irc_connecting));
+        }
+
         if (online == null) {
             online = normalize(res.getDrawable(R.drawable.icq_status_online));
         }
@@ -1758,6 +1773,9 @@ public class resources {
             yandex_online = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_yandex_online.png"));
             yandex_offline = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_yandex_offline.png"));
             yandex_connecting = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_yandex_connecting.png"));
+            irc_online = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_irc_online.png"));
+            irc_offline = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_irc_offline.png"));
+            irc_connecting = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_irc_connecting.png"));
             online = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_online.png"));
             offline = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_offline.png"));
             connecting = normalize(Drawable.createFromPath(JASMINE_SD_PATH + "Skin/sts_connecting.png"));

--- a/app/src/main/res/values/drawable_aliases.xml
+++ b/app/src/main/res/values/drawable_aliases.xml
@@ -1,0 +1,5 @@
+<resources>
+    <item name="irc_online" type="drawable">@drawable/xmpp_online</item>
+    <item name="irc_offline" type="drawable">@drawable/xmpp_offline</item>
+    <item name="irc_connecting" type="drawable">@drawable/xmpp_connecting</item>
+</resources>

--- a/app/src/main/res/values/public.xml
+++ b/app/src/main/res/values/public.xml
@@ -233,6 +233,9 @@
     <public name="ya_connecting" id="0x7f0200e6" type="drawable" />
     <public name="ya_offline" id="0x7f0200e7" type="drawable" />
     <public name="ya_online" id="0x7f0200e8" type="drawable" />
+    <public name="irc_connecting" id="0x7f0200e9" type="drawable" />
+    <public name="irc_offline" id="0x7f0200ea" type="drawable" />
+    <public name="irc_online" id="0x7f0200eb" type="drawable" />
     <public name="about" id="0x7f030000" type="layout" />
     <public name="ach" id="0x7f030001" type="layout" />
     <public name="add_contact_dialog" id="0x7f030002" type="layout" />


### PR DESCRIPTION
## Summary
- provide IRC online/offline/connecting icons
- expose IRC icons through `resources`
- handle IRC profiles in `ContactListActivity`
- remove binary icon files and use drawable aliases

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_687fc27348448323a9ebd6df487f3300