### PR TITLE
Use constants instead of numeric literals

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/BReceiver.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/BReceiver.java
@@ -47,10 +47,10 @@ public class BReceiver extends BroadcastReceiver {
             if (intent.getAction().contains("RINGER_MODE_CHANGED")) {
                 AudioManager am = (AudioManager) this.service.getSystemService(Context.AUDIO_SERVICE);
                 switch (am.getRingerMode()) {
-                    case 1:
+                    case AudioManager.RINGER_MODE_VIBRATE:
                         Media.ring_mode = 1;
                         return;
-                    case 2:
+                    case AudioManager.RINGER_MODE_NORMAL:
                         Media.ring_mode = 0;
                         return;
                     default:

--- a/app/src/main/java/ru/ivansuper/jasmin/Media.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Media.java
@@ -39,7 +39,7 @@ public class Media {
         if (ring_mode == 0 && phone_mode == 0) {
             try {
                 switch (event) {
-                    case 0:
+                    case INC_MSG:
                         if (MediaTable.inc_msg_e) {
                             this.mp.reset();
                             if (MediaTable.inc_msg.equals("$*INTERNAL*$")) {
@@ -56,7 +56,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 1:
+                    case AUTH_ACCEPTED:
                         if (MediaTable.auth_accepted_e) {
                             this.mp.reset();
                             if (MediaTable.auth_accepted.equals("$*INTERNAL*$")) {
@@ -73,7 +73,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 2:
+                    case AUTH_DENIED:
                         if (MediaTable.auth_denied_e) {
                             this.mp.reset();
                             if (MediaTable.auth_denied.equals("$*INTERNAL*$")) {
@@ -90,7 +90,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 3:
+                    case AUTH_REQUEST:
                         if (MediaTable.auth_req_e) {
                             this.mp.reset();
                             if (MediaTable.auth_req.equals("$*INTERNAL*$")) {
@@ -107,7 +107,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 4:
+                    case CONTACT_IN:
                         if (MediaTable.contact_in_e) {
                             this.mp.reset();
                             if (MediaTable.contact_in.equals("$*INTERNAL*$")) {
@@ -124,7 +124,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 5:
+                    case CONTACT_OUT:
                         if (MediaTable.contact_out_e) {
                             this.mp.reset();
                             if (MediaTable.contact_out.equals("$*INTERNAL*$")) {
@@ -141,7 +141,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 6:
+                    case INC_FILE:
                         if (MediaTable.inc_file_e) {
                             this.mp.reset();
                             if (MediaTable.inc_file.equals("$*INTERNAL*$")) {
@@ -158,7 +158,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 7:
+                    case OUT_MSG:
                         if (MediaTable.out_msg_e) {
                             this.mp.reset();
                             if (MediaTable.out_msg.equals("$*INTERNAL*$")) {
@@ -175,7 +175,7 @@ public class Media {
                             break;
                         }
                         break;
-                    case 8:
+                    case TRANSFER_REJECTED:
                         if (MediaTable.transfer_rejected_e) {
                             if (MediaTable.transfer_rejected.equals("$*INTERNAL*$")) {
                                 this.mp.reset();

--- a/app/src/main/java/ru/ivansuper/jasmin/ProfilesAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ProfilesAdapter.java
@@ -8,6 +8,9 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import java.util.Vector;
 
+import ru.ivansuper.jasmin.Service.EventTranslator;
+import ru.ivansuper.jasmin.jabber.JProfile;
+
 /* loaded from: classes.dex */
 public class ProfilesAdapter extends BaseAdapter {
     public Vector<ProfilesAdapterItem> profiles = new Vector<>();
@@ -56,28 +59,28 @@ public class ProfilesAdapter extends BaseAdapter {
         label.setPadding(10, 0, 0, 0);
         ImageView icon = new ImageView(resources.ctx);
         switch (this.profiles.get(arg0).profile_type) {
-            case 0:
+            case EventTranslator.PROFILE_TYPE_ICQ:
                 icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.icq_status_online));
                 break;
-            case 1:
+            case EventTranslator.PROFILE_TYPE_JABBER:
                 switch (this.profiles.get(arg0).proto_type) {
-                    case 0:
+                    case JProfile.TYPE_XMPP:
                         icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.xmpp));
                         break;
-                    case 1:
+                    case JProfile.TYPE_VK:
                         icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.vk_online));
                         break;
-                    case 2:
+                    case JProfile.TYPE_YANDEX:
                         icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.ya_online));
                         break;
-                    case 3:
+                    case JProfile.TYPE_GTALK:
                         icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.gtalk_online));
                         break;
-                    case 4:
+                    case JProfile.TYPE_QIP:
                         icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.qip_online));
                         break;
                 }
-            case 2:
+            case EventTranslator.PROFILE_TYPE_MRIM:
                 icon.setImageDrawable(resources.ctx.getResources().getDrawable(R.drawable.mrim_contact_status_online));
                 break;
             case 3:

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQProfile.java
@@ -1962,15 +1962,15 @@ public class ICQProfile extends IMProfile {
                 String account = msg.sender;
                 int res = AntispamBot.checkQuestion(account, msg.message, this);
                 switch (res) {
-                    case 0:
+                    case AntispamBot.BANNED:
                         return;
-                    case 1:
+                    case AntispamBot.NEED_QUEST:
                         ICQMessageChannel1 message = new ICQMessageChannel1(this.sequence, msg.sender, this.svc.getAntispamQuestion(), false, msg.cookie);
                         userSend(message.data);
                         jasminSvc.pla.put(this.nickname, utilities.match(resources.getString("s_message_locked"), new String[]{this.ID, msg.sender, preview}), resources.msg_in, null, popup_log_adapter.MESSAGE_DISPLAY_TIME, null);
                         this.svc.put_log(this.nickname + ": " + utilities.match(resources.getString("s_message_locked"), new String[]{this.ID, msg.sender, preview}));
                         return;
-                    case 2:
+                    case AntispamBot.ACCEPTED:
                         ICQMessageChannel1 message2 = new ICQMessageChannel1(this.sequence, msg.sender, this.svc.getAntispamAllowed(), false, msg.cookie);
                         userSend(message2.data);
                         msg.message = resources.getString("s_contact_allowed");
@@ -1989,15 +1989,15 @@ public class ICQProfile extends IMProfile {
                 String account2 = msg.sender;
                 int res2 = AntispamBot.checkQuestion(account2, msg.message, this);
                 switch (res2) {
-                    case 0:
+                    case AntispamBot.BANNED:
                         return;
-                    case 1:
+                    case AntispamBot.NEED_QUEST:
                         ICQMessageChannel1 message3 = new ICQMessageChannel1(this.sequence, msg.sender, this.svc.getAntispamQuestion(), false, msg.cookie);
                         userSend(message3.data);
                         jasminSvc.pla.put(this.nickname, utilities.match(resources.getString("s_message_locked"), new String[]{this.ID, msg.sender, preview}), resources.msg_in, null, popup_log_adapter.MESSAGE_DISPLAY_TIME, null);
                         this.svc.put_log(this.nickname + ": " + utilities.match(resources.getString("s_message_locked"), new String[]{this.ID, msg.sender, preview}));
                         return;
-                    case 2:
+                    case AntispamBot.ACCEPTED:
                         ICQMessageChannel1 message4 = new ICQMessageChannel1(this.sequence, msg.sender, this.svc.getAntispamAllowed(), false, msg.cookie);
                         userSend(message4.data);
                         contact.as_accepted = true;

--- a/app/src/main/java/ru/ivansuper/jasmin/ui/MyTextView.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ui/MyTextView.java
@@ -235,7 +235,7 @@ public class MyTextView extends View implements Handler.Callback {
     @Override // android.view.View
     public boolean dispatchTouchEvent(MotionEvent event) {
         try {
-            if (event.getAction() == 0) {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
                 this.mClickHandled = false;
                 this.mLongClickHandled = false;
                 int idx = getCharIndexFromCoordinate(event.getX(), event.getY());
@@ -259,7 +259,7 @@ public class MyTextView extends View implements Handler.Callback {
                 }
             }
             switch (event.getAction()) {
-                case 1:
+                case MotionEvent.ACTION_UP:
                     removeHighlight();
                     if (!this.mLongClickHandled) {
                         this.mClickHandled = true;
@@ -271,8 +271,8 @@ public class MyTextView extends View implements Handler.Callback {
                         }
                     }
                     break;
-                case 3:
-                case 4:
+                case MotionEvent.ACTION_CANCEL:
+                case MotionEvent.ACTION_OUTSIDE:
                     this.mClickHandled = true;
                     removeHighlight();
                     break;


### PR DESCRIPTION
## Summary
- remove magic numbers in ringer mode handling
- use event constants in `Media`
- replace magic numbers in profile adapter
- replace AntispamBot numeric codes
- use `MotionEvent` constants for touch handling

## Testing
- `./gradlew test --dry-run` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6880079db32c8323867e071840263fe0