### PR TITLE
Add avatar size preference

### DIFF
--- a/app/src/main/assets/defaults/prefs_map.xml
+++ b/app/src/main/assets/defaults/prefs_map.xml
@@ -2,6 +2,7 @@
 <map>
 <boolean name="ms_restore_conf_presence" value="true" />
 <string name="ms_cl_font_size">15</string>
+<string name="ms_cl_avatar_size">40</string>
 <boolean name="ms_offline" value="true" />
 <boolean name="ms_auto_open_keyboard" value="true" />
 <string name="ms_wallpaper_type">0</string>

--- a/app/src/main/assets/locale/EN.txt
+++ b/app/src/main/assets/locale/EN.txt
@@ -654,6 +654,7 @@ s_ms_simple_list := Solid list
 s_ms_simple_list_desc := Solid list w/o separation by profiles and by groups
 s_ms_cl_columns := Columns count
 s_ms_cl_font_size := Font size
+s_ms_cl_avatar_size := Avatar size
 s_ms_show_away := Show status
 s_ms_show_away_desc := Show status text under contacts
 s_ms_show_avatars := Show avatars

--- a/app/src/main/assets/locale/RU.txt
+++ b/app/src/main/assets/locale/RU.txt
@@ -654,6 +654,7 @@ s_ms_simple_list := Литой список
 s_ms_simple_list_desc := Отображение без разделения на профили и без разделения на группы
 s_ms_cl_columns := Количество колонок
 s_ms_cl_font_size := Размер шрифта
+s_ms_cl_avatar_size := Размер аватара
 s_ms_show_away := Показывать статус
 s_ms_show_away_desc := Показывать текст статуса под контактами
 s_ms_show_avatars := Показывать аватары

--- a/app/src/main/assets/locale/UA.txt
+++ b/app/src/main/assets/locale/UA.txt
@@ -654,6 +654,7 @@ s_ms_simple_list := Литий список
 s_ms_simple_list_desc := Відображення без поділу на профілі і без поділу на групи
 s_ms_cl_columns := Кількість колонок
 s_ms_cl_font_size := Розмір шрифту
+s_ms_cl_avatar_size := Розмір аватара
 s_ms_show_away := Показувати статус
 s_ms_show_away_desc := Показувати текст статусу під контактами
 s_ms_show_avatars := Показувати аватари

--- a/app/src/main/java/ru/ivansuper/jasmin/Preferences/Manager.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Preferences/Manager.java
@@ -46,18 +46,23 @@ public class Manager {
             int density = metrics.densityDpi;
             int fontSize;
             int smileScale;
+            int avatarSize;
             if (density >= DisplayMetrics.DENSITY_XXHIGH) {
                 fontSize = 24;
                 smileScale = 320;
+                avatarSize = 48;
             } else if (density >= DisplayMetrics.DENSITY_XHIGH) {
                 fontSize = 20;
                 smileScale = 240;
+                avatarSize = 44;
             } else if (density >= DisplayMetrics.DENSITY_HIGH) {
                 fontSize = 18;
                 smileScale = 180;
+                avatarSize = 40;
             } else {
                 fontSize = 15;
                 smileScale = 160;
+                avatarSize = 36;
             }
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(resources.ctx);
@@ -66,6 +71,7 @@ public class Manager {
             editor.putString("ms_chat_text_size", String.valueOf(fontSize));
             editor.putString("ms_chat_time_size", String.valueOf(fontSize));
             editor.putString("ms_smileys_scale", String.valueOf(smileScale));
+            editor.putString("ms_cl_avatar_size", String.valueOf(avatarSize));
             editor.apply();
         }
     }

--- a/app/src/main/java/ru/ivansuper/jasmin/Preferences/PreferenceTable.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Preferences/PreferenceTable.java
@@ -23,6 +23,8 @@ public class PreferenceTable {
     public static boolean chat_dividers;
     public static boolean chat_zebra;
     public static int clTextSize;
+    /** Size of contact list avatars in density-independent pixels */
+    public static int clAvatarSize;
     public static boolean enable_x_in_bottom_panel;
     public static boolean hideEmptyGroups;
     public static boolean hideOffline;

--- a/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
@@ -122,7 +122,7 @@ public class RosterItemView extends View {
 
     public RosterItemView(Context var1) {
         super(var1);
-        int var2 = (int)(40.0F * resources.dm.density);
+        int var2 = (int) (PreferenceTable.clAvatarSize * resources.dm.density);
         this.avatar_back = (NinePatchDrawable)this.getContext().getResources().getDrawable(R.drawable.avatar_back);
         this.avatar_back.setBounds(0, 0, var2, var2);
         this.name_ = new TextPaint();
@@ -356,7 +356,7 @@ public class RosterItemView extends View {
     }
 
     private final void reset() {
-        int var1 = (int)(40.0F * resources.dm.density);
+        int var1 = (int) (PreferenceTable.clAvatarSize * resources.dm.density);
         Rect var2 = new Rect();
         this.avatar_back.getPadding(var2);
         this.avatar_bounds = new Rect(var2.left, var2.top, var1 - var2.right, var1 - var2.bottom);

--- a/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
@@ -1438,6 +1438,11 @@ public class jasminSvc extends Service implements SharedPreferences.OnSharedPref
             this.sharedPreferences.edit().putString("ms_cl_font_size", "16").commit();
         }
         try {
+            PreferenceTable.clAvatarSize = Integer.parseInt(this.sharedPreferences.getString("ms_cl_avatar_size", "40"));
+        } catch (Exception e) {
+            this.sharedPreferences.edit().putString("ms_cl_avatar_size", "40").commit();
+        }
+        try {
             PreferenceTable.chatTextSize = Integer.parseInt(this.sharedPreferences.getString("ms_chat_text_size", "16"));
         } catch (Exception e2) {
             this.sharedPreferences.edit().putString("ms_chat_text_size", "16").commit();

--- a/app/src/main/java/ru/ivansuper/jasmin/UAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/UAdapter.java
@@ -9,6 +9,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import java.util.Vector;
 import ru.ivansuper.jasmin.color_editor.ColorScheme;
+import ru.ivansuper.jasmin.Preferences.PreferenceTable;
 
 /**
  * UAdapter is a custom adapter class that extends BaseAdapter.
@@ -137,7 +138,7 @@ public class UAdapter extends BaseAdapter {
      * The size of the text in the list items.
      * The default value is 16.
      */
-    private int text_size = 16;
+    private int text_size = PreferenceTable.clTextSize;
     /**
      * The current filter string used to filter the list items.
      * If empty, all items are displayed. Otherwise, only items whose labels
@@ -151,6 +152,11 @@ public class UAdapter extends BaseAdapter {
      * @noinspection FieldCanBeLocal, unused
      */
     private boolean use_shadow = false;
+
+    /** Creates a new adapter with text size taken from preferences */
+    public UAdapter() {
+        this.text_size = PreferenceTable.clTextSize;
+    }
 
     /**
      * Returns the number of items in the adapter.

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -158,6 +158,9 @@
         <ru.ivansuper.jasmin.Preferences.IntegerPickerSmall
             android:defaultValue="18"
             android:key="ms_cl_font_size" />
+        <ru.ivansuper.jasmin.Preferences.IntegerPickerSmall
+            android:defaultValue="40"
+            android:key="ms_cl_avatar_size" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="ms_show_away"


### PR DESCRIPTION
## Summary
- introduce `clAvatarSize` preference for customizing avatar dimensions
- default avatar size scales with screen density
- load new preference in service settings
- apply avatar size in contact list rendering
- expose avatar size in Settings UI and localization
- use preference-based text size as default for `UAdapter`

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68828e88d9bc832390165db3701b67ba