### PR TITLE
Add global font scale setting

### DIFF
--- a/app/src/main/assets/defaults/prefs_map.xml
+++ b/app/src/main/assets/defaults/prefs_map.xml
@@ -14,6 +14,7 @@
 <boolean name="ms_triple_vibro" value="true" />
 <boolean name="ms_use_popup" value="true" />
 <boolean name="ms_use_overscroll" value="true" />
+<string name="ms_ui_font_scale">100</string>
 <boolean name="ms_animated_smileys" value="true" />
 <string name="ms_turn_sts_timeout">300</string>
 <string name="ms_chat_style">1</string>

--- a/app/src/main/assets/locale/EN.txt
+++ b/app/src/main/assets/locale/EN.txt
@@ -731,6 +731,7 @@ s_ms_log_clickable := Clickable notices
 s_ms_log_clickable_desc := Open chat by clicking on a pop-up notification (for messages only). Need restart.
 s_ms_use_overscroll := Overscrolling effect
 s_ms_use_overscroll_desc := Switch on overscrolling in contact list
+s_ms_ui_font_scale := Interface font scale
 s_ms_show_xstatuses := Show extra status
 s_ms_show_clients := Show client icon
 s_ms_jabber_category := Jabber (XMPP)

--- a/app/src/main/assets/locale/RU.txt
+++ b/app/src/main/assets/locale/RU.txt
@@ -731,6 +731,7 @@ s_ms_log_clickable := Кликабельные уведомления
 s_ms_log_clickable_desc := Открывать чат при нажатии на всплывающее уведомление (только для сообщений). Нужна перезагрузка.
 s_ms_use_overscroll := Эффект перепрокрутки
 s_ms_use_overscroll_desc := Включить эффект перепрокрутки в списке контактов
+s_ms_ui_font_scale := Размер интерфейса
 s_ms_show_xstatuses := Показывать доп. статус
 s_ms_show_clients := Показывать иконки клиентов
 s_ms_jabber_category := Jabber (XMPP)

--- a/app/src/main/assets/locale/UA.txt
+++ b/app/src/main/assets/locale/UA.txt
@@ -731,6 +731,7 @@ s_ms_log_clickable:= Клікабельні повідомлення
 s_ms_log_clickable_desc:= Відкривати чат при натисканні на спливаюче повідомлення (тільки для повідомлень). Потрібна перезавантаження.
 s_ms_use_overscroll:= Ефект перепрокрутки
 s_ms_use_overscroll_desc := Увімкнути ефект перепрокрутки в списку контактів
+s_ms_ui_font_scale := Розмір інтерфейсу
 s_ms_show_xstatuses := Показувати дод. статус
 s_ms_show_clients := Показувати іконки клієнтів
 s_ms_jabber_category := Jabber (XMPP)

--- a/app/src/main/java/ru/ivansuper/jasmin/ContactHistoryActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactHistoryActivity.java
@@ -97,6 +97,7 @@ public class ContactHistoryActivity extends Activity {
                 break;
         }
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         SystemBarUtils.setupTransparentBars(this);
         setVolumeControlStream(3);
         setContentView(R.layout.contact_history);

--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -206,6 +206,7 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
     public void onCreate(Bundle savedInstanceState) {
         this.IT_IS_PORTRAIT = true;
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         Intent i = getIntent();
         //noinspection deprecation
         sp = PreferenceManager.getDefaultSharedPreferences(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/FileBrowserActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/FileBrowserActivity.java
@@ -31,6 +31,7 @@ public class FileBrowserActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         setVolumeControlStream(3);
         setContentView(R.layout.file_browser_activity);
         SystemBarUtils.setupTransparentBars(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/HistoryTools/ExportImportActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/HistoryTools/ExportImportActivity.java
@@ -51,6 +51,7 @@ public class ExportImportActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         setTheme(16973833);
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         setContentView(R.layout.import_history);
         SystemBarUtils.setupTransparentBars(this);
         initViews();

--- a/app/src/main/java/ru/ivansuper/jasmin/MainActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/MainActivity.java
@@ -44,6 +44,7 @@ public class MainActivity extends Activity implements Handler.Callback {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         getWindowManager().getDefaultDisplay().getMetrics(resources.dm);
         setContentView(R.layout.activity_main);
         SystemBarUtils.setupTransparentBars(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/MediaManagerActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/MediaManagerActivity.java
@@ -40,6 +40,7 @@ public class MediaManagerActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         sp = PreferenceManager.getDefaultSharedPreferences(this);
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         setVolumeControlStream(3);
         setContentView(R.layout.media_manager);
         SystemBarUtils.setupTransparentBars(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/Preferences/Manager.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Preferences/Manager.java
@@ -72,6 +72,7 @@ public class Manager {
             editor.putString("ms_chat_time_size", String.valueOf(fontSize));
             editor.putString("ms_smileys_scale", String.valueOf(smileScale));
             editor.putString("ms_cl_avatar_size", String.valueOf(avatarSize));
+            editor.putString("ms_ui_font_scale", "100");
             editor.apply();
         }
     }

--- a/app/src/main/java/ru/ivansuper/jasmin/Preferences/PreferenceTable.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Preferences/PreferenceTable.java
@@ -25,6 +25,8 @@ public class PreferenceTable {
     public static int clTextSize;
     /** Size of contact list avatars in density-independent pixels */
     public static int clAvatarSize;
+    /** Global interface font scale percentage */
+    public static int uiFontScale;
     public static boolean enable_x_in_bottom_panel;
     public static boolean hideEmptyGroups;
     public static boolean hideOffline;

--- a/app/src/main/java/ru/ivansuper/jasmin/ProfilesActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ProfilesActivity.java
@@ -76,6 +76,7 @@ public class ProfilesActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         setVolumeControlStream(3);
         setContentView(R.layout.profiles);
         SystemBarUtils.setupTransparentBars(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/SearchActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/SearchActivity.java
@@ -94,6 +94,7 @@ public class SearchActivity extends Activity implements Handler.Callback {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         //noinspection deprecation
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         if (sp.getBoolean("ms_sys_wallpaper", false)) {

--- a/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
@@ -1453,6 +1453,12 @@ public class jasminSvc extends Service implements SharedPreferences.OnSharedPref
             this.sharedPreferences.edit().putString("ms_chat_time_size", "14").commit();
         }
         try {
+            PreferenceTable.uiFontScale = Integer.parseInt(this.sharedPreferences.getString("ms_ui_font_scale", "100"));
+        } catch (Exception e) {
+            this.sharedPreferences.edit().putString("ms_ui_font_scale", "100").commit();
+            PreferenceTable.uiFontScale = 100;
+        }
+        try {
             PreferenceTable.vibroLength = Long.parseLong(this.sharedPreferences.getString("ms_vibro_length", "200"));
         } catch (Exception e4) {
             this.sharedPreferences.edit().putString("ms_vibro_length", "200").commit();

--- a/app/src/main/java/ru/ivansuper/jasmin/SmileysManagerActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/SmileysManagerActivity.java
@@ -51,6 +51,7 @@ public class SmileysManagerActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         //noinspection deprecation
         sp = PreferenceManager.getDefaultSharedPreferences(this);
         selectedPack = sp.getString("current_smileys_pack", "$*INTERNAL*$");

--- a/app/src/main/java/ru/ivansuper/jasmin/SmileysSelector.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/SmileysSelector.java
@@ -73,6 +73,7 @@ public class SmileysSelector extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         initializeTheme();
         initializeUI();
     }

--- a/app/src/main/java/ru/ivansuper/jasmin/color_editor/ColorEditorActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/color_editor/ColorEditorActivity.java
@@ -67,6 +67,7 @@ public class ColorEditorActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         setContentView(R.layout.color_editor);
         SystemBarUtils.setupTransparentBars(this);
         initViews();

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/GMail/GMailActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/GMail/GMailActivity.java
@@ -34,6 +34,7 @@ public class GMailActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         visible = true;
         setContentView(R.layout.google_mail);
         SystemBarUtils.setupTransparentBars(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/XMLConsole/XMLConsoleActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/XMLConsole/XMLConsoleActivity.java
@@ -46,6 +46,7 @@ public class XMLConsoleActivity extends Activity implements Handler.Callback {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        resources.applyFontScale(this);
         setContentView(R.layout.xml_console);
         SystemBarUtils.setupTransparentBars(this);
         setVolumeControlStream(3);

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/bookmarks/BookmarksActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/bookmarks/BookmarksActivity.java
@@ -61,6 +61,7 @@ public class BookmarksActivity extends Activity {
                 break;
         }
         super.onCreate(bundle);
+        resources.applyFontScale(this);
         if (PROFILE == null) {
             finish();
             return;

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/conference/BannedListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/conference/BannedListActivity.java
@@ -68,6 +68,7 @@ public class BannedListActivity extends Activity {
                 break;
         }
         super.onCreate(bundle);
+        resources.applyFontScale(this);
         setVolumeControlStream(3);
         setContentView(R.layout.banned_list);
         SystemBarUtils.setupTransparentBars(this);

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/disco/DiscoActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/disco/DiscoActivity.java
@@ -72,6 +72,7 @@ public class DiscoActivity extends Activity {
         }
         setVolumeControlStream(3);
         super.onCreate(bundle);
+        resources.applyFontScale(this);
         setContentView(R.layout.disco_activity);
         SystemBarUtils.setupTransparentBars(this);
         initViews();

--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -17,6 +17,8 @@ import android.graphics.drawable.NinePatchDrawable;
 import android.graphics.drawable.StateListDrawable;
 import android.os.Build;
 import android.os.Environment;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -2332,6 +2334,26 @@ public class resources {
         initInternalGraphics();
         res = null;
         System.gc();
+    }
+
+    /** Apply global font scale based on user preference */
+    public static void applyFontScale(Context context) {
+        if (context == null) {
+            return;
+        }
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        float scale;
+        try {
+            scale = Float.parseFloat(prefs.getString("ms_ui_font_scale", "100")) / 100f;
+        } catch (Exception e) {
+            scale = 1f;
+        }
+        Resources r = context.getResources();
+        Configuration cfg = new Configuration(r.getConfiguration());
+        if (cfg.fontScale != scale) {
+            cfg.fontScale = scale;
+            r.updateConfiguration(cfg, r.getDisplayMetrics());
+        }
     }
 
     private static void createDirectories(String... paths) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -64,4 +64,16 @@
         <item>30</item>
         <item>9999</item>
     </string-array>
+    <string-array name="font_scale_labels">
+        <item>80%</item>
+        <item>100%</item>
+        <item>120%</item>
+        <item>150%</item>
+    </string-array>
+    <string-array name="font_scale_values">
+        <item>80</item>
+        <item>100</item>
+        <item>120</item>
+        <item>150</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -301,6 +301,11 @@
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="ms_use_overscroll" />
+        <ListPreference
+            android:defaultValue="100"
+            android:entries="@array/font_scale_labels"
+            android:entryValues="@array/font_scale_values"
+            android:key="ms_ui_font_scale" />
         <ru.ivansuper.jasmin.Preferences.TransitionPicker
             android:defaultValue="3"
             android:dependency="ms_two_screens_mode"


### PR DESCRIPTION
## Summary
- add interface font scale preference
- expose array values for scaling
- load font scale in service and apply via `resources.applyFontScale`
- update activities to apply font scale on creation

## Testing
- `./gradlew help` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6882948c94708323836b3d6df6c5800f