### PR TITLE
Fix MD5 helper to avoid shared digest instance

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/MD5.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/MD5.java
@@ -5,17 +5,18 @@ import java.security.MessageDigest;
 /** @noinspection ALL*/
 public class MD5 {
     public static final byte[] AIM_MD5_STRING = "AOL Instant Messenger (SM)".getBytes();
-    private static MessageDigest md5;
+
     public static byte[] calculateMD5(byte[] bytesToHash) {
-        return md5.digest(bytesToHash);
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            return md5.digest(bytesToHash);
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            return new byte[0];
+        }
     }
 
     public static void init() {
-        try {
-            md5 = MessageDigest.getInstance("MD5");
-        } catch (Exception exception) {
-            exception.printStackTrace();
-        }
-
+        // No initialization required anymore
     }
 }


### PR DESCRIPTION
## Summary
- avoid reusing a global `MessageDigest` in `MD5` helper

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68829746033c8323817b64acc35cb648