### PR TITLE
Increase Jabber socket timeout

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/SocketConnection.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/SocketConnection.java
@@ -64,6 +64,12 @@ public abstract class SocketConnection {
     public String lastServer = "none";
     public int lastPort = 0;
 
+    /**
+     * Timeout in milliseconds used for {@link Socket#connect(java.net.SocketAddress, int)}.
+     * A longer timeout helps avoid intermittent connection failures on slow networks.
+     */
+    public static final int CONNECT_TIMEOUT_MS = 15000;
+
     public abstract void onConnect();
 
     public abstract void onConnecting();
@@ -207,7 +213,7 @@ public abstract class SocketConnection {
                 Log.v("SOCKET", "Socket options set: keepAlive, tcpNoDelay");
                 addr = new InetSocketAddress(lastServer, lastPort);
                 Log.v("SOCKET", "Connecting to " + lastServer + ":" + lastPort);
-                socket.connect(addr, popup_log_adapter.INFO_DISPLAY_TIME);
+                socket.connect(addr, CONNECT_TIMEOUT_MS);
                 Log.v("SOCKET", "Socket connected");
                 socket.setSoTimeout(0);
                 socketIn = socket.getInputStream();


### PR DESCRIPTION
## Summary
- increase the connection timeout for SocketConnection

## Testing
- `./gradlew test` *(fails: Could not open cp_settings generic class cache for settings file)*

------
https://chatgpt.com/codex/tasks/task_e_68829e9781208323affc904895eddedd