### PR TITLE
Increase Jabber socket timeout

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/icq/SocketConnection.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/SocketConnection.java
@@ -64,6 +64,12 @@ public abstract class SocketConnection {
     public String lastServer = "none";
     public int lastPort = 0;
 
+    /**
+     * Timeout in milliseconds used for {@link Socket#connect(java.net.SocketAddress, int)}.
+     * A longer timeout helps avoid intermittent connection failures on slow networks.
+     */
+    public static final int CONNECT_TIMEOUT_MS = 15000;
+
     public abstract void onConnect();
 
     public abstract void onConnecting();
@@ -207,7 +213,7 @@ public abstract class SocketConnection {
                 Log.v("SOCKET", "Socket options set: keepAlive, tcpNoDelay");
                 addr = new InetSocketAddress(lastServer, lastPort);
                 Log.v("SOCKET", "Connecting to " + lastServer + ":" + lastPort);
-                socket.connect(addr, popup_log_adapter.INFO_DISPLAY_TIME);
+                socket.connect(addr, CONNECT_TIMEOUT_MS);
                 Log.v("SOCKET", "Socket connected");
                 socket.setSoTimeout(0);
                 socketIn = socket.getInputStream();

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
@@ -503,7 +503,21 @@ public class JProfile extends IMProfile {
                 if (realm == null) {
                     realm = "";
                 }
-                Node node = new Node("response", Base64Coder.encodeString(JProtocol.getResponse(this.ID, this.PASS, realm, "xmpp/" + this.host, values.get("nonce"), "5534491fa36be80ffbade139ea1a48ac")), "urn:ietf:params:xml:ns:xmpp-sasl");
+                String cnonce = Long.toHexString(utilities.RANDOM.nextLong());
+                Node node = new Node(
+                        "response",
+                        Base64Coder.encodeString(
+                                JProtocol.getResponse(
+                                        this.ID,
+                                        this.PASS,
+                                        realm,
+                                        "xmpp/" + this.host,
+                                        values.get("nonce"),
+                                        cnonce
+                                )
+                        ),
+                        "urn:ietf:params:xml:ns:xmpp-sasl"
+                );
                 this.stream.write(node, this);
                 return;
             } catch (Exception e) {


### PR DESCRIPTION
## Summary
- increase the connection timeout for SocketConnection
- send a unique random cnonce during DIGEST-MD5 auth

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68829e9781208323affc904895eddedd