### PR TITLE
Add rounded avatar option

### DIFF
--- a/app/src/main/assets/defaults/prefs_map.xml
+++ b/app/src/main/assets/defaults/prefs_map.xml
@@ -60,5 +60,6 @@
 <string name="ms_messages_limit_value">100</string>
 <boolean name="ms_conf_show_theme" value="true" />
 <boolean name="ms_use_messages_merging" value="false" />
+<boolean name="ms_round_avatars" value="false" />
 </map>
 

--- a/app/src/main/java/ru/ivansuper/jasmin/Preferences/PreferenceTable.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Preferences/PreferenceTable.java
@@ -41,6 +41,7 @@ public class PreferenceTable {
     public static boolean ms_messages_limit_enabled;
     public static boolean ms_rejoin_to_conferences;
     public static boolean ms_show_avatars;
+    public static boolean ms_round_avatars;
     public static boolean ms_show_markers_in_chat;
     public static boolean ms_two_screens_mode;
     public static boolean ms_use_bookmark_autojoin;

--- a/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
@@ -137,7 +137,7 @@ public class RosterItemView extends View {
         this.effect.setAntiAlias(true);
         this.effect.setStrokeWidth(3.0F);
         this.avatar_path = new Path();
-        this.avatar_path.addRoundRect(new RectF(1.0F, 1.0F, (float)(var2 - 1), (float)(var2 - 1)), 5.0F, 5.0F, Direction.CCW);
+        updateAvatarPath();
         this.avatar_border_ = new Paint();
         this.avatar_border_.setColor(2013265919);
         this.avatar_border_.setStrokeWidth(0.0F);
@@ -215,6 +215,16 @@ public class RosterItemView extends View {
             this.mStatusDrawer.draw(var1);
         }
 
+    }
+
+    private void updateAvatarPath() {
+        int size = (int)(AVATAR_SIZE * resources.dm.density);
+        this.avatar_path.reset();
+        if (PreferenceTable.ms_round_avatars) {
+            this.avatar_path.addCircle(size / 2f, size / 2f, size / 2f - 1f, Direction.CCW);
+        } else {
+            this.avatar_path.addRoundRect(new RectF(1f, 1f, size - 1f, size - 1f), 5f, 5f, Direction.CCW);
+        }
     }
 
     private final float getCounterHeight() {
@@ -360,6 +370,7 @@ public class RosterItemView extends View {
         Rect var2 = new Rect();
         this.avatar_back.getPadding(var2);
         this.avatar_bounds = new Rect(var2.left, var2.top, var1 - var2.right, var1 - var2.bottom);
+        updateAvatarPath();
         this.draw_avatar = false;
         this.online = 0;
         this.total = 0;
@@ -411,7 +422,14 @@ public class RosterItemView extends View {
                     var10 = var1.save();
                     var1.translate(3.0F, 3.0F);
                     this.avatar_back.draw(var1);
-                    this.avatar.draw(var1);
+                    if (PreferenceTable.ms_round_avatars) {
+                        int clip = var1.save();
+                        var1.clipPath(this.avatar_path);
+                        this.avatar.draw(var1);
+                        var1.restoreToCount(clip);
+                    } else {
+                        this.avatar.draw(var1);
+                    }
                     var1.restoreToCount(var10);
                     var10 = 0 + this.avatar_back.getBounds().width();
                 }

--- a/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
@@ -1518,6 +1518,7 @@ public class jasminSvc extends Service implements SharedPreferences.OnSharedPref
         PreferenceTable.triple_vibro = this.sharedPreferences.getBoolean("ms_triple_vibro", true);
         PreferenceTable.ms_animated_smileys = this.sharedPreferences.getBoolean("ms_animated_smileys", true);
         PreferenceTable.ms_show_avatars = this.sharedPreferences.getBoolean("ms_show_avatars", false);
+        PreferenceTable.ms_round_avatars = this.sharedPreferences.getBoolean("ms_round_avatars", false);
         PreferenceTable.ms_chats_at_top = this.sharedPreferences.getBoolean("ms_chats_at_top", false);
         PreferenceTable.ms_chat_style = Integer.parseInt(this.sharedPreferences.getString("ms_chat_style", "0"));
         PreferenceTable.ms_dragdrop_quoting = this.sharedPreferences.getBoolean("ms_dragdrop_quoting", true);

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -168,6 +168,10 @@
             android:key="ms_show_avatars"
             android:title="Показывать аватары" />
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ms_round_avatars"
+            android:title="Круглые аватары" />
+        <CheckBoxPreference
             android:defaultValue="true"
             android:key="ms_show_xstatuses" />
         <CheckBoxPreference


### PR DESCRIPTION
## Summary
- add `ms_round_avatars` preference
- load new setting in service
- add checkbox in settings UI
- update defaults
- clip avatar to circle when option enabled

## Testing
- `./gradlew test --continue` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a66a6cec8323891ac11f2789195b