### PR TITLE
Add Telegram UI theme resources

### DIFF
--- a/app/src/main/res/drawable/telegram_bubble_in.xml
+++ b/app/src/main/res/drawable/telegram_bubble_in.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/telegram_bubble_in"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/telegram_bubble_out.xml
+++ b/app/src/main/res/drawable/telegram_bubble_out.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/telegram_bubble_out"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/telegram_button.xml
+++ b/app/src/main/res/drawable/telegram_button.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/telegram_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/telegram_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/telegram_toolbar.xml
+++ b/app/src/main/res/drawable/telegram_toolbar.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/telegram_toolbar"/>
+</shape>

--- a/app/src/main/res/layout/chat.xml
+++ b/app/src/main/res/layout/chat.xml
@@ -25,7 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:alwaysDrawnWithCache="false"
-                android:background="#77000000"
+                android:background="@drawable/telegram_toolbar"
                 android:gravity="center_vertical"
                 android:orientation="vertical">
 
@@ -162,7 +162,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:alwaysDrawnWithCache="false"
-                android:background="#77000000"
+                android:background="@drawable/telegram_toolbar"
                 android:gravity="center_horizontal"
                 android:orientation="vertical">
 
@@ -302,7 +302,7 @@
                                 android:id="@+id/chat_menu_btn"
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
-                                android:background="@drawable/btn_default_small"
+                                android:background="@drawable/telegram_button"
                                 android:drawableLeft="@drawable/ic_menu"
                                 android:paddingLeft="8sp"
                                 android:paddingRight="8sp" />
@@ -319,6 +319,7 @@
                                 android:id="@+id/chat_smiley_btn"
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
+                                android:background="@drawable/telegram_button"
                                 android:drawableLeft="@drawable/smile_button"
                                 android:gravity="center"
                                 android:paddingLeft="14sp"
@@ -328,6 +329,7 @@
                                 android:id="@+id/send"
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
+                                android:background="@drawable/telegram_button"
                                 android:paddingLeft="18sp"
                                 android:paddingRight="18sp"
                                 android:shadowColor="#ff000000"

--- a/app/src/main/res/layout/chat_xhigh.xml
+++ b/app/src/main/res/layout/chat_xhigh.xml
@@ -25,7 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:alwaysDrawnWithCache="false"
-                android:background="#77000000"
+                android:background="@drawable/telegram_toolbar"
                 android:gravity="center_vertical"
                 android:padding="5sp">
 
@@ -179,7 +179,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:alwaysDrawnWithCache="false"
-                android:background="#77000000"
+                android:background="@drawable/telegram_toolbar"
                 android:gravity="center_horizontal"
                 android:orientation="vertical">
 
@@ -319,7 +319,7 @@
                                 android:id="@+id/chat_menu_btn"
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
-                                android:background="@drawable/btn_default_small"
+                                android:background="@drawable/telegram_button"
                                 android:drawableLeft="@drawable/ic_menu"
                                 android:paddingLeft="8sp"
                                 android:paddingRight="8sp" />
@@ -336,6 +336,7 @@
                                 android:id="@+id/chat_smiley_btn"
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
+                                android:background="@drawable/telegram_button"
                                 android:drawableLeft="@drawable/smile_button"
                                 android:gravity="center"
                                 android:paddingLeft="14sp"
@@ -345,6 +346,7 @@
                                 android:id="@+id/send"
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
+                                android:background="@drawable/telegram_button"
                                 android:paddingLeft="18sp"
                                 android:paddingRight="18sp"
                                 android:shadowColor="#ff000000"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,9 @@
     <color name="transparent">#00000000</color>
     <color name="telegram_primary">#54a9eb</color>
     <color name="telegram_background">#e5f3ff</color>
+    <!-- Additional Telegram colors -->
+    <color name="telegram_accent">#0088cc</color>
+    <color name="telegram_bubble_in">#ffffff</color>
+    <color name="telegram_bubble_out">#cfe9ff</color>
+    <color name="telegram_toolbar">#54a9eb</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -38,9 +38,27 @@
         <item name="android:background">@drawable/btn_default_small</item>
     </style>
 
+    <!-- Telegram specific widget styles -->
+    <style name="TelegramButtonStyle" parent="@android:style/Widget.Button">
+        <item name="android:background">@drawable/telegram_button</item>
+        <item name="android:textColor">@android:color/white</item>
+    </style>
+
+    <style name="TelegramEditTextStyle" parent="@android:style/Widget.EditText">
+        <item name="android:background">@drawable/telegram_bubble_in</item>
+        <item name="android:textColor">@android:color/black</item>
+    </style>
+
+    <style name="TelegramListSelector" parent="@android:style/Widget.ListView">
+        <item name="android:listSelector">@drawable/telegram_bubble_out</item>
+    </style>
+
     <style name="TelegramTheme" parent="@style/BlackNoTitleTheme">
         <item name="android:windowBackground">@drawable/telegram_wallpaper</item>
         <item name="android:textColor">@color/telegram_primary</item>
+        <item name="android:buttonStyle">@style/TelegramButtonStyle</item>
+        <item name="android:editTextStyle">@style/TelegramEditTextStyle</item>
+        <item name="android:listViewStyle">@style/TelegramListSelector</item>
     </style>
 
     <style name="EditTextStyle" parent="@android:style/Widget.EditText">


### PR DESCRIPTION
## Summary
- introduce extra Telegram colors
- add bubble, toolbar and button drawables
- extend `TelegramTheme` with widget styles
- update chat layouts to use new themed resources

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b21008b8832388c1b32f4d61a6a3