### PR TITLE
Enhance Telegram style

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ChatAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ChatAdapter.java
@@ -165,6 +165,15 @@ public class ChatAdapter extends BaseAdapter {
             selector.setVisibility(View.GONE);
         }
         message.setTextSize(PreferenceTable.chatTextSize);
+        if (PreferenceTable.ms_telegram_style) {
+            if (hst.direction == 1) {
+                message.setBackgroundResource(R.drawable.telegram_bubble_in);
+                message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+            } else {
+                message.setBackgroundResource(R.drawable.telegram_bubble_out);
+                message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+            }
+        }
         if (PreferenceTable.ms_chat_style == 1) {
             status.setVisibility(View.GONE);
             if (hst.direction == 1) {

--- a/app/src/main/java/ru/ivansuper/jasmin/HistoryAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/HistoryAdapter.java
@@ -115,6 +115,15 @@ public class HistoryAdapter extends BaseAdapter {
         message.setText(hst.message);
         message.selectMatches(this.pattern);
         message.setTextSize(PreferenceTable.chatTextSize);
+        if (PreferenceTable.ms_telegram_style) {
+            if (hst.direction == 1) {
+                message.setBackgroundResource(R.drawable.telegram_bubble_in);
+                message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+            } else {
+                message.setBackgroundResource(R.drawable.telegram_bubble_out);
+                message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+            }
+        }
         if (PreferenceTable.ms_chat_style == 1) {
             status.setVisibility(View.GONE);
             if (hst.direction == 1) {

--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -28,6 +28,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import ru.ivansuper.jasmin.Preferences.PreferenceTable;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -598,7 +599,9 @@ public class resources {
      * @noinspection unused
      */
     public static void attachIngMsg(View view) {
-        if (incoming_message_back != null) {
+        if (PreferenceTable.ms_telegram_style) {
+            view.setBackgroundResource(R.drawable.telegram_bubble_in);
+        } else if (incoming_message_back != null) {
             view.setBackgroundDrawable(new NinePatchDrawable(ctx.getResources(), incoming_message_back, incoming_message_back.getNinePatchChunk(), incoming_message_back_padding, null));
         }
 
@@ -615,7 +618,9 @@ public class resources {
      * @noinspection unused
      */
     public static void attachOutMsg(View view) {
-        if (outgoing_message_back != null) {
+        if (PreferenceTable.ms_telegram_style) {
+            view.setBackgroundResource(R.drawable.telegram_bubble_out);
+        } else if (outgoing_message_back != null) {
             view.setBackgroundDrawable(new NinePatchDrawable(ctx.getResources(), outgoing_message_back, outgoing_message_back.getNinePatchChunk(), outgoing_message_back_padding, null));
         }
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,6 @@
     <color name="telegram_bubble_in">#ffffff</color>
     <color name="telegram_bubble_out">#cfe9ff</color>
     <color name="telegram_toolbar">#54a9eb</color>
+    <color name="telegram_text_primary">#000000</color>
+    <color name="telegram_text_secondary">#7f7f7f</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,9 +53,21 @@
         <item name="android:listSelector">@drawable/telegram_bubble_out</item>
     </style>
 
+    <style name="TelegramMessageIncoming" parent="@style/TextViewStyle">
+        <item name="android:background">@drawable/telegram_bubble_in</item>
+        <item name="android:textColor">@color/telegram_text_primary</item>
+    </style>
+
+    <style name="TelegramMessageOutgoing" parent="@style/TextViewStyle">
+        <item name="android:background">@drawable/telegram_bubble_out</item>
+        <item name="android:textColor">@color/telegram_text_primary</item>
+    </style>
+
     <style name="TelegramTheme" parent="@style/BlackNoTitleTheme">
         <item name="android:windowBackground">@drawable/telegram_wallpaper</item>
         <item name="android:textColor">@color/telegram_primary</item>
+        <item name="android:textColorPrimary">@color/telegram_text_primary</item>
+        <item name="android:textColorSecondary">@color/telegram_text_secondary</item>
         <item name="android:buttonStyle">@style/TelegramButtonStyle</item>
         <item name="android:editTextStyle">@style/TelegramEditTextStyle</item>
         <item name="android:listViewStyle">@style/TelegramListSelector</item>


### PR DESCRIPTION
## Summary
- add Telegram-themed colors
- tweak Telegram styles
- show Telegram bubbles in chat adapters
- use Telegram bubbles in resources when style is enabled

## Testing
- `./gradlew test --console=plain --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b6180d408323adf91525c76d4726