### PR TITLE
Improve Telegram chat bubble visuals

### DIFF
--- a/app/src/main/res/drawable/telegram_bubble_in.xml
+++ b/app/src/main/res/drawable/telegram_bubble_in.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <solid android:color="@color/telegram_bubble_in"/>
-    <corners android:radius="8dp"/>
-</shape>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/telegram_bubble_in"/>
+            <corners android:radius="8dp"/>
+        </shape>
+    </item>
+    <item android:gravity="bottom|left">
+        <rotate android:fromDegrees="45" android:toDegrees="45">
+            <shape android:shape="rectangle">
+                <size android:width="8dp" android:height="8dp"/>
+                <solid android:color="@color/telegram_bubble_in"/>
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/telegram_bubble_out.xml
+++ b/app/src/main/res/drawable/telegram_bubble_out.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <solid android:color="@color/telegram_bubble_out"/>
-    <corners android:radius="8dp"/>
-</shape>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/telegram_bubble_out"/>
+            <corners android:radius="8dp"/>
+        </shape>
+    </item>
+    <item android:gravity="bottom|right">
+        <rotate android:fromDegrees="45" android:toDegrees="45">
+            <shape android:shape="rectangle">
+                <size android:width="8dp" android:height="8dp"/>
+                <solid android:color="@color/telegram_bubble_out"/>
+            </shape>
+        </rotate>
+    </item>
+</layer-list>


### PR DESCRIPTION
## Summary
- update Telegram-style message bubbles so they have pointer arrows

## Testing
- `./gradlew tasks --all` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b8b3025083239e0c23b2011c836f