### PR TITLE
Improve Telegram-style chat bubbles

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ChatAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ChatAdapter.java
@@ -12,6 +12,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.view.Gravity;
 
 import java.util.ArrayList;
 
@@ -139,6 +140,7 @@ public class ChatAdapter extends BaseAdapter {
         TextView time = msg.findViewById(R.id.msg_time);
         MyTextView message = msg.findViewById(R.id.msg_text);
         message.setFocusable(false);
+        LinearLayout msgContainer = msg.findViewById(R.id.msg_container);
         LinearLayout status = msg.findViewById(R.id.msg_status);
         ImageView sts = msg.findViewById(R.id.msg_sts_icon);
         CheckBox selector = msg.findViewById(R.id.chat_item_checkbox);
@@ -169,9 +171,11 @@ public class ChatAdapter extends BaseAdapter {
             if (hst.direction == 1) {
                 message.setBackgroundResource(R.drawable.telegram_bubble_in);
                 message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+                ((LinearLayout.LayoutParams) msgContainer.getLayoutParams()).gravity = Gravity.START;
             } else {
                 message.setBackgroundResource(R.drawable.telegram_bubble_out);
                 message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+                ((LinearLayout.LayoutParams) msgContainer.getLayoutParams()).gravity = Gravity.END;
             }
         }
         if (PreferenceTable.ms_chat_style == 1) {

--- a/app/src/main/res/layout/chat_item.xml
+++ b/app/src/main/res/layout/chat_item.xml
@@ -67,7 +67,8 @@
                         android:background="#ffaaaa00" />
 
                     <LinearLayout
-                        android:layout_width="match_parent"
+                        android:id="@+id/msg_container"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
 
@@ -76,7 +77,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_margin="2sp"
-                            android:layout_weight="1" />
+                            android:textColor="@color/telegram_text_primary" />
 
                         <LinearLayout
                             android:id="@+id/transfer_layout"


### PR DESCRIPTION
## Summary
- give message bubble container a dedicated id and width wrap_content
- ensure chat text color is readable
- align bubbles left or right depending on direction

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6882bad4a5248323b2e95e0f7a4cab44