### PR TITLE
Move Telegram style controls

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
@@ -546,6 +546,7 @@ public class ICQChatActivity extends Chat {
         linearLayout.setBackgroundColor(ColorScheme.getColor(9));
         resources.attachChatTopPanel(TOP_PANEL);
         resources.attachChatBottomPanel(linearLayout);
+        resources.swapPanelsForTelegram(chat_back, TOP_PANEL, linearLayout);
         nick_.setTextSize(PreferenceTable.chatTextSize);
         this.input.setTextSize(PreferenceTable.chatTextSize);
         nick_.setTextColor(ColorScheme.getColor(22));

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/JChatActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/JChatActivity.java
@@ -62,6 +62,8 @@ public class JChatActivity extends Chat implements Handler.Callback {
     /** @noinspection FieldCanBeLocal*/
     @SuppressLint("StaticFieldLeak")
     private static LinearLayout TOP_PANEL;
+    @SuppressLint("StaticFieldLeak")
+    private static LinearLayout chat_back;
     public static JContact contact;
     @SuppressLint("StaticFieldLeak")
     private static LinearLayout opened_chats_markers;
@@ -614,6 +616,7 @@ public class JChatActivity extends Chat implements Handler.Callback {
     public void initViews() {
         super.initViews();
         this.quot_view = (QuotingView) findViewById(R.id.chat_quoting_view);
+        chat_back = (LinearLayout) findViewById(R.id.chat_back);
         this.mainStatus = (ImageView) findViewById(R.id.mainStatus);
         this.xStatus = (ImageView) findViewById(R.id.xStatus);
         this.nickname = (TextView) findViewById(R.id.nickname);
@@ -762,6 +765,7 @@ public class JChatActivity extends Chat implements Handler.Callback {
         }
         resources.attachChatTopPanel(TOP_PANEL);
         resources.attachChatBottomPanel(linearLayout);
+        resources.swapPanelsForTelegram(chat_back, TOP_PANEL, linearLayout);
         opened_chats_markers = (LinearLayout) findViewById(R.id.chat_chats_markers);
         opened_chats_markers.setVisibility(PreferenceTable.ms_show_markers_in_chat ? View.VISIBLE : View.GONE);
         this.nick_.setTextSize(PreferenceTable.chatTextSize);

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/JConference.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/JConference.java
@@ -1011,6 +1011,7 @@ public class JConference extends Chat implements Handler.Callback {
         }
         resources.attachChatTopPanel(TOP_PANEL);
         resources.attachChatBottomPanel(bottomPanel);
+        resources.swapPanelsForTelegram(chat_back, TOP_PANEL, bottomPanel);
 
         // Text styles
         nick_.setTextSize(PreferenceTable.chatTextSize);

--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -23,6 +23,7 @@ import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -2375,6 +2376,32 @@ public class resources {
                 e.printStackTrace();
             }
         }
+    }
+
+    /**
+     * Repositions the chat header and bottom panel when Telegram style is enabled.
+     * <p>
+     * When {@link PreferenceTable#ms_telegram_style} is {@code true}, the bottom panel
+     * is moved to the top of the specified parent and the header is placed at the
+     * bottom. This mimics Telegram's layout where controls are positioned above the
+     * chat list.
+     *
+     * @param parent      Parent container holding both panels
+     * @param header      View representing the page header
+     * @param bottomPanel View representing the bottom panel
+     */
+    public static void swapPanelsForTelegram(ViewGroup parent, View header, View bottomPanel) {
+        if (!PreferenceTable.ms_telegram_style) {
+            return;
+        }
+        if (parent == null || header == null || bottomPanel == null) {
+            return;
+        }
+
+        parent.removeView(bottomPanel);
+        parent.removeView(header);
+        parent.addView(bottomPanel, 0);
+        parent.addView(header);
     }
 
     public static boolean sd_mounted() {


### PR DESCRIPTION
## Summary
- add helper to swap chat header with bottom panel when Telegram theme is active
- update chat activities to call the new helper
- store `chat_back` container in `JChatActivity`

## Testing
- `./gradlew tasks --all` *(fails: Unsupported class file major version 65)*
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6882c0aeb6dc832391bd3846e6440861