### PR TITLE
Implement Telegram-style time bubble

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ChatAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ChatAdapter.java
@@ -156,6 +156,7 @@ public class ChatAdapter extends BaseAdapter {
         }
         TextView daySep = msg.findViewById(R.id.msg_day_separator);
         TextView time = msg.findViewById(R.id.msg_time);
+        TextView timeBottom = msg.findViewById(R.id.msg_time_bottom);
         MyTextView message = msg.findViewById(R.id.msg_text);
         message.setFocusable(false);
         LinearLayout msgContainer = msg.findViewById(R.id.msg_container);
@@ -177,9 +178,12 @@ public class ChatAdapter extends BaseAdapter {
             }
         }
         time.setText(hst.formattedDate);
+        timeBottom.setText(hst.formattedDate);
         nick.setTextSize(PreferenceTable.chatTextSize);
         time.setTextSize(PreferenceTable.chatTimeSize);
+        timeBottom.setTextSize(PreferenceTable.chatTimeSize);
         time.setTextColor(ColorScheme.getColor(10));
+        timeBottom.setTextColor(ColorScheme.getColor(10));
         if (hst.message == null) {
             hst.message = "NULL";
         }
@@ -192,17 +196,23 @@ public class ChatAdapter extends BaseAdapter {
         }
         message.setTextSize(PreferenceTable.chatTextSize);
         if (PreferenceTable.ms_telegram_style) {
+            time.setVisibility(View.GONE);
+            timeBottom.setVisibility(View.VISIBLE);
             if (hst.direction == 1) {
                 message.setBackgroundResource(R.drawable.telegram_bubble_in);
                 message.setTextColor(0xffffffff);
                 ((LinearLayout.LayoutParams) msgContainer.getLayoutParams()).gravity = Gravity.START;
+                ((LinearLayout.LayoutParams) timeBottom.getLayoutParams()).gravity = Gravity.START;
             } else {
                 message.setBackgroundResource(R.drawable.telegram_bubble_out);
                 message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
                 ((LinearLayout.LayoutParams) msgContainer.getLayoutParams()).gravity = Gravity.END;
+                ((LinearLayout.LayoutParams) timeBottom.getLayoutParams()).gravity = Gravity.END;
             }
         }
         if (!PreferenceTable.ms_telegram_style) {
+            time.setVisibility(View.VISIBLE);
+            timeBottom.setVisibility(View.GONE);
             if (PreferenceTable.ms_chat_style == 1) {
                 status.setVisibility(View.GONE);
                 if (hst.direction == 1) {

--- a/app/src/main/java/ru/ivansuper/jasmin/HistoryAdapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/HistoryAdapter.java
@@ -10,6 +10,7 @@ import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.view.Gravity;
 import java.util.Vector;
 import ru.ivansuper.jasmin.Preferences.PreferenceTable;
 import ru.ivansuper.jasmin.color_editor.ColorScheme;
@@ -97,15 +98,19 @@ public class HistoryAdapter extends BaseAdapter {
             nick.setVisibility(View.GONE);
         }
         TextView time = msg.findViewById(R.id.msg_time);
+        TextView timeBottom = msg.findViewById(R.id.msg_time_bottom);
         MyTextView message = msg.findViewById(R.id.msg_text);
         CheckBox selector = msg.findViewById(R.id.chat_item_checkbox);
         LinearLayout status = msg.findViewById(R.id.msg_status);
         ImageView sts = msg.findViewById(R.id.msg_sts_icon);
         HistoryItem hst = getItem(position);
         time.setText(hst.formattedDate);
+        timeBottom.setText(hst.formattedDate);
         nick.setTextSize(PreferenceTable.chatTextSize - 2);
         time.setTextSize(PreferenceTable.chatTextSize);
+        timeBottom.setTextSize(PreferenceTable.chatTextSize);
         time.setTextColor(ColorScheme.getColor(10));
+        timeBottom.setTextColor(ColorScheme.getColor(10));
         if (ContactHistoryActivity.multiquoting) {
             selector.setVisibility(View.VISIBLE);
             selector.setChecked(hst.selected);
@@ -116,13 +121,20 @@ public class HistoryAdapter extends BaseAdapter {
         message.selectMatches(this.pattern);
         message.setTextSize(PreferenceTable.chatTextSize);
         if (PreferenceTable.ms_telegram_style) {
+            time.setVisibility(View.GONE);
+            timeBottom.setVisibility(View.VISIBLE);
             if (hst.direction == 1) {
                 message.setBackgroundResource(R.drawable.telegram_bubble_in);
                 message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+                ((LinearLayout.LayoutParams) timeBottom.getLayoutParams()).gravity = Gravity.START;
             } else {
                 message.setBackgroundResource(R.drawable.telegram_bubble_out);
                 message.setTextColor(ctx.getResources().getColor(R.color.telegram_text_primary));
+                ((LinearLayout.LayoutParams) timeBottom.getLayoutParams()).gravity = Gravity.END;
             }
+        } else {
+            time.setVisibility(View.VISIBLE);
+            timeBottom.setVisibility(View.GONE);
         }
         if (PreferenceTable.ms_chat_style == 1) {
             status.setVisibility(View.GONE);

--- a/app/src/main/res/layout/chat_item.xml
+++ b/app/src/main/res/layout/chat_item.xml
@@ -138,6 +138,15 @@
                             </LinearLayout>
                         </LinearLayout>
                     </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/msg_time_bottom"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="2dp"
+                        android:textSize="12sp"
+                        android:textColor="@color/telegram_text_secondary"
+                        android:visibility="gone" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/app/src/main/res/values/public.xml
+++ b/app/src/main/res/values/public.xml
@@ -420,6 +420,7 @@
     <public name="chat_item_top_panel" id="0x7f0b0052" type="id" />
     <public name="msg_sts_icon" id="0x7f0b0053" type="id" />
     <public name="msg_time" id="0x7f0b0054" type="id" />
+    <public name="msg_time_bottom" id="0x7f0b0135" type="id" />
     <public name="msg_status" id="0x7f0b0055" type="id" />
     <public name="msg_text" id="0x7f0b0056" type="id" />
     <public name="transfer_layout" id="0x7f0b0057" type="id" />


### PR DESCRIPTION
## Summary
- add a `msg_time_bottom` view in chat_item
- expose new id in `public.xml`
- update `ChatAdapter` and `HistoryAdapter` to place time inside bubbles when Telegram theme is on

## Testing
- `./gradlew assembleDebug` *(fails: Plugin not found)*
- `./gradlew test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c446fca08323b6564afaa8435f44