### PR TITLE
Implement round avatars option

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/RosterItemView.java
@@ -418,7 +418,9 @@ public class RosterItemView extends View {
                 if (this.draw_avatar) {
                     var10 = var1.save();
                     var1.translate(3.0F, 3.0F);
-                    this.avatar_back.draw(var1);
+                    if (!PreferenceTable.ms_round_avatars) {
+                        this.avatar_back.draw(var1);
+                    }
                     if (PreferenceTable.ms_round_avatars) {
                         int clip = var1.save();
                         var1.clipPath(this.avatar_path);

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/ICQChatActivity.java
@@ -39,6 +39,7 @@ import ru.ivansuper.jasmin.UAdapter;
 import ru.ivansuper.jasmin.base.ach.ADB;
 import ru.ivansuper.jasmin.color_editor.ColorScheme;
 import ru.ivansuper.jasmin.dialogs.DialogBuilder;
+import ru.ivansuper.jasmin.utils.ImageUtils;
 import ru.ivansuper.jasmin.icq.FileTransfer.FileReceiver;
 import ru.ivansuper.jasmin.icq.FileTransfer.FileSender;
 import ru.ivansuper.jasmin.icq.FileTransfer.FileTransfer;
@@ -372,6 +373,9 @@ public class ICQChatActivity extends Chat {
             }
             if (contact.avatar == null) {
                 bmp = ((BitmapDrawable) resources.ctx.getResources().getDrawable(R.drawable.no_avatar)).getBitmap();
+            }
+            if (PreferenceTable.ms_round_avatars) {
+                bmp = ru.ivansuper.jasmin.utils.ImageUtils.toRoundBitmap(bmp);
             }
             avatar.setImageBitmap(bmp);
         }

--- a/app/src/main/java/ru/ivansuper/jasmin/chats/JChatActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/chats/JChatActivity.java
@@ -33,6 +33,7 @@ import ru.ivansuper.jasmin.HistoryItem;
 import ru.ivansuper.jasmin.Preferences.PreferenceTable;
 import ru.ivansuper.jasmin.R;
 import ru.ivansuper.jasmin.UAdapter;
+import ru.ivansuper.jasmin.utils.ImageUtils;
 import ru.ivansuper.jasmin.base.ach.ADB;
 import ru.ivansuper.jasmin.color_editor.ColorScheme;
 import ru.ivansuper.jasmin.dialogs.DialogBuilder;
@@ -541,6 +542,9 @@ public class JChatActivity extends Chat implements Handler.Callback {
             }
             if (contact.avatar == null) {
                 bmp = ((BitmapDrawable) resources.ctx.getResources().getDrawable(R.drawable.no_avatar)).getBitmap();
+            }
+            if (PreferenceTable.ms_round_avatars) {
+                bmp = ru.ivansuper.jasmin.utils.ImageUtils.toRoundBitmap(bmp);
             }
             avatar.setImageBitmap(bmp);
         }

--- a/app/src/main/java/ru/ivansuper/jasmin/utils/ImageUtils.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/utils/ImageUtils.java
@@ -1,0 +1,29 @@
+package ru.ivansuper.jasmin.utils;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.RectF;
+
+/** Utility methods for working with images. */
+public class ImageUtils {
+    /**
+     * Returns a circular version of the given {@link Bitmap}.
+     * The resulting bitmap has width and height equal to the
+     * smaller dimension of the source bitmap.
+     */
+    public static Bitmap toRoundBitmap(Bitmap src) {
+        if (src == null) return null;
+        int size = Math.min(src.getWidth(), src.getHeight());
+        Bitmap out = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(out);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        RectF rect = new RectF(0, 0, size, size);
+        canvas.drawOval(rect, paint);
+        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
+        canvas.drawBitmap(src, null, rect, paint);
+        return out;
+    }
+}


### PR DESCRIPTION
## Summary
- skip avatar frame when round avatars enabled
- support round avatar bitmaps in chat header
- provide helper for creating round bitmaps

## Testing
- `./gradlew tasks --all | head` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6882ca22f0348323920727bc4177318b