### PR TITLE
Add configurable avatar server address

### DIFF
--- a/app/src/main/assets/defaults/prefs_map.xml
+++ b/app/src/main/assets/defaults/prefs_map.xml
@@ -31,6 +31,7 @@
 <boolean name="ms_dragdrop_quoting" value="true" />
 <boolean name="ms_log_online" value="true" />
 <string name="ms_port">5190</string>
+<string name="ms_avatar_base_url">http://45.144.154.209</string>
 <boolean name="ms_nick_in_chat" value="true" />
 <boolean name="ms_log_xtraz_reading" value="true" />
 <boolean name="ms_typing_notify" value="true" />

--- a/app/src/main/assets/locale/EN.txt
+++ b/app/src/main/assets/locale/EN.txt
@@ -627,6 +627,7 @@ s_ms_server_settings := Network
 s_ms_server_settings_icq := ICQ
 s_ms_server := Server
 s_ms_port := Port
+s_ms_avatar_base_url := Avatar server
 s_ms_auth_method := Authentication method
 s_ms_server_settings_keepalive := Connection
 s_ms_use_ping := Forced ping

--- a/app/src/main/assets/locale/RU.txt
+++ b/app/src/main/assets/locale/RU.txt
@@ -627,6 +627,7 @@ s_ms_server_settings := Сеть
 s_ms_server_settings_icq := ICQ
 s_ms_server := Сервер
 s_ms_port := Порт
+s_ms_avatar_base_url := Сервер аватаров
 s_ms_auth_method := Метод аутентификации
 s_ms_server_settings_keepalive := Поддержание подключения
 s_ms_use_ping := Принудительный

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQContact.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQContact.java
@@ -22,6 +22,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Vector;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
 import ru.ivansuper.jasmin.Clients.ClientInfo;
 import ru.ivansuper.jasmin.ContactlistItem;
 import ru.ivansuper.jasmin.HistoryItem;
@@ -99,7 +102,9 @@ public class ICQContact extends ContactlistItem {
             @Override
             public void run() {
                 try {
-                    URL url = new URL("http://45.144.154.209/avatar/" + UIN + "?hq=1");
+                    SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(resources.ctx);
+                    String base = sp.getString("ms_avatar_base_url", "http://45.144.154.209");
+                    URL url = new URL(base + "/avatar/" + UIN + "?hq=1");
                     HttpURLConnection c = (HttpURLConnection) url.openConnection();
                     if (c.getResponseCode() == 200) {
                         InputStream in = new BufferedInputStream(c.getInputStream());
@@ -221,7 +226,9 @@ public class ICQContact extends ContactlistItem {
             public void run() {
                 try {
                     File avatar_file = new File(resources.dataPath + ICQContact.this.profile.ID + "/avatars/" + ICQContact.this.ID);
-                    URL url = new URL("http://45.144.154.209/avatar/" + contact.ID);
+                    SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(resources.ctx);
+                    String base = sp.getString("ms_avatar_base_url", "http://45.144.154.209");
+                    URL url = new URL(base + "/avatar/" + contact.ID);
                     HttpURLConnection c = (HttpURLConnection) url.openConnection();
 
                     if (c.getResponseCode() == 200) {

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -47,6 +47,11 @@
             android:key="ms_port"
             android:negativeButtonText="Отмена"
             android:positiveButtonText="Ok" />
+        <EditTextPreference
+            android:defaultValue="http://45.144.154.209"
+            android:key="ms_avatar_base_url"
+            android:negativeButtonText="Отмена"
+            android:positiveButtonText="Ok" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/auth_methods"


### PR DESCRIPTION
## Summary
- fetch avatar server address from preferences instead of using a hardcoded URL
- expose new `ms_avatar_base_url` setting
- provide defaults and translations

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68834e31e20083238873208ba7b7fcc4