### PR TITLE
Fix contact list sorting on Android 2.3

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactlistItem.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactlistItem.java
@@ -84,11 +84,13 @@ public abstract class ContactlistItem implements Comparable<ContactlistItem> {
                 if (a == b) {
                     lvl++;
                 } else {
-                    return Integer.compare(a, b);
+                    return IntegerCompat.compare(a, b);
                 }
             }
 
-            return Integer.compare(nameA.length(), nameB.length());
+            int lenA = nameA.length();
+            int lenB = nameB.length();
+            return IntegerCompat.compare(lenA, lenB);
 
         } catch (Exception e) {
             //noinspection CallToPrintStackTrace

--- a/app/src/main/java/ru/ivansuper/jasmin/IntegerCompat.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/IntegerCompat.java
@@ -1,0 +1,13 @@
+package ru.ivansuper.jasmin;
+
+/**
+ * Minimal compatibility helper for integer comparisons on older API levels.
+ * Mirrors the behavior of {@code Integer.compare} introduced in later Java versions.
+ */
+public final class IntegerCompat {
+    private IntegerCompat() {}
+
+    public static int compare(int a, int b) {
+        return a < b ? -1 : (a == b ? 0 : 1);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid using Integer.compare in `ContactlistItem`
- add `IntegerCompat` helper for legacy API levels

## Testing
- `./gradlew --no-daemon test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68839779e0948323bcbb3c362b4c8a44