### PR TITLE
Add progress notifications for avatar updates

### DIFF
--- a/app/src/main/assets/locale/EN.txt
+++ b/app/src/main/assets/locale/EN.txt
@@ -156,6 +156,7 @@ s_import_colors_success := Import completed
 //Misc
 //=============================
 s_changing_avatar := Changing avatar ...
+s_loading_avatar := Loading avatar ...
 s_change_avatar_error_1 := Timeout, avatar didn't change
 s_change_avatar_error_2 := Error, avatar didn't change
 s_change_avatar_success := Avatar updated

--- a/app/src/main/assets/locale/RU.txt
+++ b/app/src/main/assets/locale/RU.txt
@@ -156,6 +156,7 @@ s_import_colors_success := Импорт цветовой схемы заверш
 //Misc
 //=============================
 s_changing_avatar := Смена аватара ...
+s_loading_avatar := Загрузка аватара ...
 s_change_avatar_error_1 := Таймаут операции, аватар не изменен
 s_change_avatar_error_2 := Ошибка, аватар не изменен
 s_change_avatar_success := Аватар успешно обновлен

--- a/app/src/main/assets/locale/UA.txt
+++ b/app/src/main/assets/locale/UA.txt
@@ -156,6 +156,7 @@ s_import_colors_success := Імпорт схеми кольору виконан
 //Misc
 //=============================
 s_changing_avatar := Заміна аватари ...
+s_loading_avatar := Завантаження аватара ...
 s_change_avatar_error_1 := Таймаут операції, аватара не оновлена
 s_change_avatar_error_2 := Помилка, аватара не оновлена
 s_change_avatar_success := Аватара успішно оновлена

--- a/app/src/main/java/ru/ivansuper/jasmin/MMP/MMPContact.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/MMP/MMPContact.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import ru.ivansuper.jasmin.locale.Locale;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Vector;
@@ -152,6 +153,7 @@ public class MMPContact extends ContactlistItem {
             @Override
             public void run() {
                 try {
+                    service.showAvatarProgress(Locale.getString("s_loading_avatar"));
                     File avatar_file = new File(resources.dataPath + MMPContact.this.profile.ID + "/avatars/" + MMPContact.this.ID);
                     String url_ = "http://obraz.foto.mail.ru/" + MMPProtocol.retreiveDomain(contact.ID) + "/" + MMPProtocol.retreiveLogin(contact.ID) + "/_mrimavatarsmall";
                     Log.e("AvatarURL", url_);
@@ -175,6 +177,7 @@ public class MMPContact extends ContactlistItem {
                                 in.close();
                                 fos.close();
                                 ByteCache.recycle(buffer);
+                                service.cancelAvatarProgress();
                                 jasminSvc jasminsvc = service;
                                 final MMPContact mMPContact = contact;
                                 jasminsvc.runOnUi(new Runnable() {
@@ -193,8 +196,11 @@ public class MMPContact extends ContactlistItem {
                             }
                         } catch (Exception e2) {
                         }
+                        service.cancelAvatarProgress();
                     }
+                    service.cancelAvatarProgress();
                 } catch (Exception e3) {
+                    service.cancelAvatarProgress();
                     e3.printStackTrace();
                 }
             }

--- a/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
@@ -111,6 +111,7 @@ public class jasminSvc extends Service implements SharedPreferences.OnSharedPref
     public static final int MESSAGE_NOTIFY_ID = 65530;
     public static final int ANTISPAM_NOTIFY_ID = 65531;
     public static final int MULTICONNECT_NOTIFY_ID = 65532;
+    public static final int AVATAR_PROGRESS_NOTIFY_ID = 65533;
 
     public static final String ACTION_PING = "ru.ivansuper.jasmin.PING";
 
@@ -933,6 +934,26 @@ public class jasminSvc extends Service implements SharedPreferences.OnSharedPref
 
     public void cancelMessageNotification(int id) {
         this.notificationManager.cancel(id);
+    }
+
+    @SuppressLint("NotificationPermission")
+    public void showAvatarProgress(CharSequence text) {
+        Notification.Builder builder;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            builder = new Notification.Builder(this, CHANNEL_ID);
+        } else {
+            builder = new Notification.Builder(this);
+        }
+        builder.setSmallIcon(R.drawable.no_avatar)
+                .setContentTitle(text)
+                .setProgress(0, 0, true)
+                .setOngoing(true);
+
+        this.notificationManager.notify(AVATAR_PROGRESS_NOTIFY_ID, builder.build());
+    }
+
+    public void cancelAvatarProgress() {
+        this.notificationManager.cancel(AVATAR_PROGRESS_NOTIFY_ID);
     }
 
     /** @noinspection unused*/

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/AvatarProtocol.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/AvatarProtocol.java
@@ -7,6 +7,7 @@ import java.io.File;
 
 import ru.ivansuper.jasmin.resources;
 
+import ru.ivansuper.jasmin.locale.Locale;
 /**
  * Handles the ICQ avatar protocol for uploading and retrieving user avatars.
  * This class manages the connection to the avatar server, sends and receives
@@ -115,6 +116,7 @@ public class AvatarProtocol {
             @Override
             public void run() {
                 AvatarProtocol.this.profile.svc.displayProgress(resources.getString("s_changing_avatar"));
+                AvatarProtocol.this.profile.svc.showAvatarProgress(Locale.getString("s_changing_avatar"));
                 try {
                     AvatarProtocol.this.send(ICQProtocol.createAvatarUpload(file, AvatarProtocol.this.sequence));
                     sleep(7000L);
@@ -124,6 +126,7 @@ public class AvatarProtocol {
                     }
                 } catch (Exception e) {
                     AvatarProtocol.this.profile.svc.cancelProgress();
+                    AvatarProtocol.this.profile.svc.cancelAvatarProgress();
                     //noinspection CallToPrintStackTrace
                     e.printStackTrace();
                 }
@@ -171,6 +174,7 @@ public class AvatarProtocol {
     /** @noinspection unused*/
     private void handleServerUploadReply(ByteBuffer data, int flags) {
         this.profile.svc.cancelProgress();
+        this.profile.svc.cancelAvatarProgress();
         int unknown = data.readDWord();
         if (unknown == 257) {
             if (data.writePos - data.readPos > 4) {

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/ICQContact.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/ICQContact.java
@@ -26,6 +26,7 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
 import ru.ivansuper.jasmin.Clients.ClientInfo;
+import ru.ivansuper.jasmin.locale.Locale;
 import ru.ivansuper.jasmin.ContactlistItem;
 import ru.ivansuper.jasmin.HistoryItem;
 import ru.ivansuper.jasmin.HistoryTools.ExportImportActivity;
@@ -102,6 +103,7 @@ public class ICQContact extends ContactlistItem {
             @Override
             public void run() {
                 try {
+                    service.showAvatarProgress(Locale.getString("s_loading_avatar"));
                     SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(resources.ctx);
                     String base = sp.getString("ms_avatar_base_url", "http://45.144.154.209");
                     URL url = new URL(base + "/avatar/" + UIN + "?hq=1");
@@ -114,7 +116,9 @@ public class ICQContact extends ContactlistItem {
                             callback.notify(icon, 0);
                         }
                     }
+                    service.cancelAvatarProgress();
                 } catch (Exception e) {
+                    service.cancelAvatarProgress();
                     //noinspection CallToPrintStackTrace
                     e.printStackTrace();
                 }
@@ -225,6 +229,7 @@ public class ICQContact extends ContactlistItem {
             @Override
             public void run() {
                 try {
+                    service.showAvatarProgress(Locale.getString("s_loading_avatar"));
                     File avatar_file = new File(resources.dataPath + ICQContact.this.profile.ID + "/avatars/" + ICQContact.this.ID);
                     SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(resources.ctx);
                     String base = sp.getString("ms_avatar_base_url", "http://45.144.154.209");
@@ -261,7 +266,7 @@ public class ICQContact extends ContactlistItem {
                                 }
 
                                 ByteCache.recycle(buffer);
-
+                                service.cancelAvatarProgress();
                                 service.runOnUi(new Runnable() {
                                     @Override
                                     public void run() {
@@ -281,8 +286,11 @@ public class ICQContact extends ContactlistItem {
                         } catch (Exception e2) {
                             // ignore
                         }
+                        service.cancelAvatarProgress();
                     }
+                    service.cancelAvatarProgress();
                 } catch (Exception e3) {
+                    service.cancelAvatarProgress();
                     //noinspection CallToPrintStackTrace
                     e3.printStackTrace();
                 }

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
@@ -2561,6 +2561,7 @@ public class JProfile extends IMProfile {
             this.svc.showToast(Locale.getString("s_change_avatar_invalid_image"), 1);
             return;
         }
+        this.svc.showAvatarProgress(Locale.getString("s_changing_avatar"));
         PacketHandler h = new PacketHandler(z) { // from class: ru.ivansuper.jasmin.jabber.JProfile.24
             @Override // ru.ivansuper.jasmin.jabber.PacketHandler
             public void execute() {
@@ -2574,6 +2575,7 @@ public class JProfile extends IMProfile {
                 } else {
                     JProfile.this.svc.showToast(Locale.getString("s_change_avatar_error_2"), 1);
                 }
+                JProfile.this.svc.cancelAvatarProgress();
                 progress.dismiss();
             }
         };


### PR DESCRIPTION
## Summary
- add constant and helpers for avatar progress notifications
- notify avatar upload progress in ICQ AvatarProtocol
- show/cancel notification when updating Jabber avatar
- display progress when downloading avatars

## Testing
- `./gradlew test` *(fails: unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688cfb09f69c8323ac0be13b28a8b6e3