### PR TITLE
Fix NullPointer crash on startup

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/resources.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/resources.java
@@ -2297,7 +2297,6 @@ public class resources {
 
         // Store all application files on external storage so they are easily
         // accessible via the built-in file browser.
-        dataPath = JASMINE_SD_PATH;
 
         am = ctx.getAssets();
         Locale.prepare();
@@ -2309,6 +2308,7 @@ public class resources {
             SD_PATH = ctx.getFilesDir().getAbsolutePath();
         }
         JASMINE_SD_PATH = SD_PATH + "/Jasmine/";
+        dataPath = JASMINE_SD_PATH;
         JASMINE_LOG_PATH = JASMINE_SD_PATH + "Logs/";
         JASMINE_INCOMING_FILES_PATH = JASMINE_SD_PATH + "RcvdFiles/";
         JASMINE_JHA_PATH = JASMINE_SD_PATH + "Jasmine History Archive/";

--- a/app/src/main/java/ru/ivansuper/jasmin/utilities.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/utilities.java
@@ -1128,6 +1128,9 @@ public class utilities {
      * @return The normalized file path string, guaranteed to end with a file separator.
      */
     public static String normalizePath(String path) {
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
         if (!path.endsWith(File.separator)) {
             return path + File.separator;
         }


### PR DESCRIPTION
## Summary
- fix dataPath initialization in `resources.putContext`
- avoid NPE in `utilities.normalizePath`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0305db7883239ec7ac612dd48cd0