### PR TITLE
feat: modernize settings theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,7 +56,7 @@
             android:finishOnTaskLaunch="true"
             android:launchMode="singleTask"
             android:noHistory="false"
-            android:theme="@android:style/Theme.Black.NoTitleBar" />
+            android:theme="@style/SettingsTheme" />
 
         <activity
             android:name="ContactHistoryActivity"

--- a/app/src/main/res/values-v19/styles.xml
+++ b/app/src/main/res/values-v19/styles.xml
@@ -14,4 +14,14 @@
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">true</item>
     </style>
+
+    <!-- Modern theme for the Settings screen on Android 4.4+ -->
+    <style name="SettingsTheme" parent="@android:style/Theme.DeviceDefault">
+        <item name="android:buttonStyle">@style/ButtonStyle</item>
+        <item name="android:editTextStyle">@style/EditTextStyle</item>
+        <item name="android:textViewStyle">@style/TextViewStyle</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Material theme for the Settings screen on Android 5.0+ -->
+    <style name="SettingsTheme" parent="@android:style/Theme.Material">
+        <item name="android:buttonStyle">@style/ButtonStyle</item>
+        <item name="android:editTextStyle">@style/EditTextStyle</item>
+        <item name="android:textViewStyle">@style/TextViewStyle</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,6 +17,9 @@
         <item name="android:textViewStyle">@style/TextViewStyle</item>
     </style>
 
+    <!-- Theme used for the Settings screen on legacy Android versions -->
+    <style name="SettingsTheme" parent="@style/BlackNoTitleTheme" />
+
     <style name="ListViewStyle" parent="@android:style/Widget.ListView">
         <item name="android:listSelector">@drawable/list_selector_background</item>
     </style>


### PR DESCRIPTION
## Summary
- add dedicated SettingsTheme and apply to SettingsActivity
- introduce Material-based settings theme for API 21+

## Testing
- `./gradlew assembleDebug` *(fails: Plugin [id: 'com.android.application', version: '7.4.2', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895bc33b7d4832390cba7c01cc3a0c5