### PR TITLE
Ensure settings sub-screens honor system bar insets

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/SettingsActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/SettingsActivity.java
@@ -121,6 +121,18 @@ public class SettingsActivity extends PreferenceActivity {
         super.onPause();
     }
 
+    @Override
+    public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
+        boolean result = super.onPreferenceTreeClick(preferenceScreen, preference);
+        if (preference instanceof PreferenceScreen) {
+            Dialog dialog = ((PreferenceScreen) preference).getDialog();
+            if (dialog != null) {
+                SystemBarUtils.setupTransparentBars(dialog);
+            }
+        }
+        return result;
+    }
+
     /**
      * Sets up the behavior and interactions for specific preferences within the given PreferenceScreen.
      * This method is responsible for:

--- a/app/src/main/java/ru/ivansuper/jasmin/utils/SystemBarUtils.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/utils/SystemBarUtils.java
@@ -1,6 +1,8 @@
 package ru.ivansuper.jasmin.utils;
 
 import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
 import android.os.Build;
 import android.view.View;
 import android.view.Window;
@@ -42,8 +44,39 @@ public class SystemBarUtils {
         }
     }
 
-    private static int getInternalDimen(Activity activity, String name) {
-        int resId = activity.getResources().getIdentifier(name, "dimen", "android");
-        return resId > 0 ? activity.getResources().getDimensionPixelSize(resId) : 0;
+    public static void setupTransparentBars(Dialog dialog) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && dialog != null) {
+            Window window = dialog.getWindow();
+            if (window == null) return;
+            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+
+            final View root = window.findViewById(android.R.id.content);
+            if (root == null) return;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+                root.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+                    @Override
+                    public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+                        v.setPadding(
+                                v.getPaddingLeft(),
+                                insets.getSystemWindowInsetTop(),
+                                v.getPaddingRight(),
+                                insets.getSystemWindowInsetBottom());
+                        return insets.consumeSystemWindowInsets();
+                    }
+                });
+                root.requestApplyInsets();
+            } else {
+                int top = getInternalDimen(dialog.getContext(), "status_bar_height");
+                int bottom = getInternalDimen(dialog.getContext(), "navigation_bar_height");
+                root.setPadding(root.getPaddingLeft(), top, root.getPaddingRight(), bottom);
+            }
+        }
+    }
+
+    private static int getInternalDimen(Context context, String name) {
+        int resId = context.getResources().getIdentifier(name, "dimen", "android");
+        return resId > 0 ? context.getResources().getDimensionPixelSize(resId) : 0;
     }
 }


### PR DESCRIPTION
## Summary
- Pad settings sub-screen dialogs for status and navigation bars
- Generalize system bar utility to work with dialogs and context

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.android.application', version: '7.4.2', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c89252fc8323a4af426653977ba4