### PR TITLE
feat: modernize EditText appearance

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ui/MEditText.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ui/MEditText.java
@@ -27,7 +27,7 @@ public class MEditText extends EditText {
     }
 
     private void init() {
-        setBackgroundResource(R.drawable.edit_text);
+        setBackgroundResource(R.drawable.edittext_background);
         resources.attachEditText(this);
     }
 }

--- a/app/src/main/res/drawable/edittext_background.xml
+++ b/app/src/main/res/drawable/edittext_background.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:state_enabled="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent"/>
+            <stroke android:width="2dp" android:color="@android:color/holo_blue_light"/>
+            <corners android:radius="4dp"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent"/>
+            <stroke android:width="1dp" android:color="@android:color/darker_gray"/>
+            <corners android:radius="4dp"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,7 +37,10 @@
     </style>
 
     <style name="EditTextStyle" parent="@android:style/Widget.EditText">
-        <item name="android:background">@drawable/edit_text</item>
+        <item name="android:background">@drawable/edittext_background</item>
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textColorHint">@android:color/darker_gray</item>
+        <item name="android:padding">12dp</item>
     </style>
 
     <style name="DialogTheme" parent="@android:style/Theme.Dialog">


### PR DESCRIPTION
## Summary
- modern EditText theme with explicit text colors and padding
- add state-list drawable for focused EditText styling
- point custom MEditText widget at the new background

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6895d07fb86c8323a4d7f7066b6cc83d