### PR TITLE
Disable avatar progress dialogs

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/ContactListActivity.java
@@ -758,9 +758,7 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
 
 
     private void uploadJabberAvatar(File file) {
-        Dialog progress = DialogBuilder.createProgress(this, Locale.getString("s_please_wait"), true);
-        progress.show();
-        contextJProfile.updateAvatar(file, progress);
+        contextJProfile.updateAvatar(file);
     }
 
     public void showDialogA(int id) {
@@ -818,7 +816,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                                     @Override
                                     public void run() {
                                         setPriority(1);
-                                        service.displayProgress(Locale.getString("s_refreshing_avatars"));
                                         Vector<ICQContact> list = contextProfile.contactlist.getContacts();
                                         for (ICQContact contact : list) {
                                             contact.getAvatar(contact, service);
@@ -827,7 +824,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                                             } catch (InterruptedException ignored) {
                                             }
                                         }
-                                        service.cancelProgress();
                                     }
                                 };
                                 t.start();
@@ -1738,7 +1734,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                                     @Override
                                     public void run() {
                                         setPriority(1);
-                                        service.displayProgress(Locale.getString("s_refreshing_avatars"));
                                         Vector<JContact> list = contextJProfile.getOnlyContacts();
                                         for (JContact contact : list) {
                                             contact.getAvatar();
@@ -1747,7 +1742,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                                             } catch (InterruptedException ignored) {
                                             }
                                         }
-                                        service.cancelProgress();
                                     }
                                 };
                                 t.start();
@@ -2162,7 +2156,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                                     @Override
                                     public void run() {
                                         setPriority(1);
-                                        service.displayProgress(Locale.getString("s_refreshing_avatars"));
                                         Vector<MMPContact> list = contextMrimProfile.getContacts();
                                         for (MMPContact contact : list) {
                                             contact.getAvatar(contact, service);
@@ -2171,7 +2164,6 @@ public class ContactListActivity extends JFragmentActivity implements Handler.Ca
                                             } catch (InterruptedException ignored) {
                                             }
                                         }
-                                        service.cancelProgress();
                                     }
                                 };
                                 t.start();

--- a/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/Service/jasminSvc.java
@@ -938,22 +938,11 @@ public class jasminSvc extends Service implements SharedPreferences.OnSharedPref
 
     @SuppressLint("NotificationPermission")
     public void showAvatarProgress(CharSequence text) {
-        Notification.Builder builder;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            builder = new Notification.Builder(this, CHANNEL_ID);
-        } else {
-            builder = new Notification.Builder(this);
-        }
-        builder.setSmallIcon(R.drawable.no_avatar)
-                .setContentTitle(text)
-                .setProgress(0, 0, true)
-                .setOngoing(true);
-
-        this.notificationManager.notify(AVATAR_PROGRESS_NOTIFY_ID, builder.build());
+        // Avatar upload/download progress is now handled silently.
     }
 
     public void cancelAvatarProgress() {
-        this.notificationManager.cancel(AVATAR_PROGRESS_NOTIFY_ID);
+        // No progress notification to cancel.
     }
 
     /** @noinspection unused*/

--- a/app/src/main/java/ru/ivansuper/jasmin/icq/AvatarProtocol.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/icq/AvatarProtocol.java
@@ -7,7 +7,6 @@ import java.io.File;
 
 import ru.ivansuper.jasmin.resources;
 
-import ru.ivansuper.jasmin.locale.Locale;
 /**
  * Handles the ICQ avatar protocol for uploading and retrieving user avatars.
  * This class manages the connection to the avatar server, sends and receives
@@ -115,8 +114,6 @@ public class AvatarProtocol {
         Thread t = new Thread() {
             @Override
             public void run() {
-                AvatarProtocol.this.profile.svc.displayProgress(resources.getString("s_changing_avatar"));
-                AvatarProtocol.this.profile.svc.showAvatarProgress(Locale.getString("s_changing_avatar"));
                 try {
                     AvatarProtocol.this.send(ICQProtocol.createAvatarUpload(file, AvatarProtocol.this.sequence));
                     sleep(7000L);
@@ -125,8 +122,6 @@ public class AvatarProtocol {
                         throw new Exception();
                     }
                 } catch (Exception e) {
-                    AvatarProtocol.this.profile.svc.cancelProgress();
-                    AvatarProtocol.this.profile.svc.cancelAvatarProgress();
                     //noinspection CallToPrintStackTrace
                     e.printStackTrace();
                 }
@@ -173,8 +168,6 @@ public class AvatarProtocol {
 
     /** @noinspection unused*/
     private void handleServerUploadReply(ByteBuffer data, int flags) {
-        this.profile.svc.cancelProgress();
-        this.profile.svc.cancelAvatarProgress();
         int unknown = data.readDWord();
         if (unknown == 257) {
             if (data.writePos - data.readPos > 4) {

--- a/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/jabber/JProfile.java
@@ -2554,15 +2554,13 @@ public class JProfile extends IMProfile {
         }
     }
 
-    public final void updateAvatar(File file, final Dialog progress) {
-        boolean z = false;
+    public final void updateAvatar(File file) {
         Bitmap avatar = Avatar.normalizeAvatar(file);
         if (avatar == null) {
             this.svc.showToast(Locale.getString("s_change_avatar_invalid_image"), 1);
             return;
         }
-        this.svc.showAvatarProgress(Locale.getString("s_changing_avatar"));
-        PacketHandler h = new PacketHandler(z) { // from class: ru.ivansuper.jasmin.jabber.JProfile.24
+        PacketHandler h = new PacketHandler(false) { // from class: ru.ivansuper.jasmin.jabber.JProfile.24
             @Override // ru.ivansuper.jasmin.jabber.PacketHandler
             public void execute() {
                 Node stanzas = this.slot;
@@ -2575,8 +2573,6 @@ public class JProfile extends IMProfile {
                 } else {
                     JProfile.this.svc.showToast(Locale.getString("s_change_avatar_error_2"), 1);
                 }
-                JProfile.this.svc.cancelAvatarProgress();
-                progress.dismiss();
             }
         };
         putPacketHandler(h);


### PR DESCRIPTION
## Summary
- Remove notifications that were displayed during avatar upload/download
- Strip progress dialogs from avatar refresh operations

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a053d8ae2c83238d94f37c1d8e65ba