### PR TITLE
Fix file browser crash when leaving app directory

### DIFF
--- a/app/src/main/java/ru/ivansuper/jasmin/FileBrowserActivity.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/FileBrowserActivity.java
@@ -3,6 +3,7 @@ package ru.ivansuper.jasmin;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Environment;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
@@ -37,7 +38,10 @@ public class FileBrowserActivity extends Activity {
         SystemBarUtils.setupTransparentBars(this);
         initViews();
         adp = new files_adapter();
-        File sd = new File(resources.SD_PATH);
+        File sd = Environment.getExternalStorageDirectory();
+        if (sd == null) {
+            sd = new File(resources.SD_PATH);
+        }
         adp.setData(sd.listFiles(), sd.getParentFile());
         list.setAdapter(adp);
         list.setOnItemClickListener(new AdapterView.OnItemClickListener() {

--- a/app/src/main/java/ru/ivansuper/jasmin/files_adapter.java
+++ b/app/src/main/java/ru/ivansuper/jasmin/files_adapter.java
@@ -35,19 +35,21 @@ public class files_adapter extends BaseAdapter {
         this.icons.clear();
         this.parent = parent;
         this.list.clear();
-        for (File file : list) {
-            try {
-                if (file.isDirectory()) {
-                    this.dirs.add(file);
-                } else {
-                    this.files.add(file);
+        if (list != null) {
+            for (File file : list) {
+                try {
+                    if (file.isDirectory()) {
+                        this.dirs.add(file);
+                    } else {
+                        this.files.add(file);
+                    }
+                    this.icons.add(null);
+                } catch (Exception e) {
+                    this.dirs.clear();
+                    this.files.clear();
+                    this.list.clear();
+                    this.list.add(parent);
                 }
-                this.icons.add(null);
-            } catch (Exception e) {
-                this.dirs.clear();
-                this.files.clear();
-                this.list.clear();
-                this.list.add(parent);
             }
         }
         Collections.sort(this.dirs);


### PR DESCRIPTION
## Summary
- Avoid `NullPointerException` in file browser adapter when directory contents are unavailable
- Start file browser at external storage root instead of app-specific directory

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a06147513083239c1bef4c484303cb